### PR TITLE
feat: Add Parser node moving functions.  lint fixes.  Test cases.

### DIFF
--- a/lexparse.go
+++ b/lexparse.go
@@ -19,7 +19,12 @@ package lexparse
 import "context"
 
 // LexParse runs the Lexer passing lexemes to the parser functions.
-func LexParse[V any](ctx context.Context, r BufferedRuneReader, initState State, initFn ParseFn[V]) (*Tree[V], error) {
+func LexParse[V comparable](
+	ctx context.Context,
+	r BufferedRuneReader,
+	initState State,
+	initFn ParseFn[V],
+) (*Tree[V], error) {
 	l := NewLexer(r, initState)
 	p := NewParser[V](l.Lex(ctx))
 	return p.Parse(ctx, initFn)

--- a/parser.go
+++ b/parser.go
@@ -157,7 +157,8 @@ func (p *Parser[V]) Pop() *Node[V] {
 // position of its parent node.  The original parent node becomes a
 // child of the current node.  All other child nodes of the original
 // parent remain unchanged, except for the current node which becomes
-// the new parent.
+// the new parent. If RotateLeft is called on the root node then
+// ErrMissingRequiredNode is returned.
 func (p *Parser[V]) RotateLeft() (*Node[V], error) {
 	// n = node , op = original parent , gp = grand parent
 	n := p.node
@@ -208,7 +209,8 @@ func (p *Parser[V]) RotateLeft() (*Node[V], error) {
 	return n, nil
 }
 
-// AdoptSibling moves the current node's previous sibling into the node's child.
+// AdoptSibling moves the current node's previous sibling into the node's
+// child. If no previous sibling exists, ErrMissingRequiredNode is returned.
 func (p *Parser[V]) AdoptSibling() (*Node[V], error) {
 	// n = node , op = original parent , s = sibling
 	n := p.node

--- a/parser.go
+++ b/parser.go
@@ -22,10 +22,13 @@ import (
 
 // TODO(#459): Implement parser
 
+// Tree is the parse tree data structure.
 type Tree[V any] struct {
+	// Root points to the root Node in the parse tree.
 	Root *Node[V]
 }
 
+// Node is the structure for a single node in the parse tree.
 type Node[V any] struct {
 	Parent   *Node[V]
 	Children []*Node[V]
@@ -33,9 +36,10 @@ type Node[V any] struct {
 	// TODO: Position,Line,Column in original input.
 }
 
-// FIXME: Remove channel
+// FIXME: Remove channel.
 type ParseFn[V any] func(context.Context, *Parser[V]) (ParseFn[V], error)
 
+// NewParser creates a new Parser that reads from the lexemes channel.
 func NewParser[V any](lexemes <-chan *Lexeme) *Parser[V] {
 	root := &Node[V]{}
 	p := &Parser[V]{
@@ -48,6 +52,7 @@ func NewParser[V any](lexemes <-chan *Lexeme) *Parser[V] {
 	return p
 }
 
+// Parser reads the lexemes produced by a Lexer and builds a parse tree.
 type Parser[V any] struct {
 	lexemes <-chan *Lexeme
 
@@ -59,6 +64,10 @@ type Parser[V any] struct {
 	lexeme *Lexeme
 }
 
+// Parse builds a parse tree by repeatedly calling parseFn.  parseFn
+// takes cxt and the Parser as arguments and returns the parseFn and
+// an error.  The parse tree is built when parseFn returns nil for the
+// parseFn.  Parsing can be cancelled by ctx.
 func (p *Parser[V]) Parse(ctx context.Context, parseFn ParseFn[V]) (*Tree[V], error) {
 	for {
 		if parseFn == nil {
@@ -83,6 +92,7 @@ func (p *Parser[V]) Parse(ctx context.Context, parseFn ParseFn[V]) (*Tree[V], er
 	return p.Tree(), nil
 }
 
+// Tree returns the parse Tree.
 func (p *Parser[V]) Tree() *Tree[V] {
 	return p.tree
 }
@@ -136,5 +146,85 @@ func (p *Parser[V]) Node(v V) *Node[V] {
 func (p *Parser[V]) Pop() *Node[V] {
 	n := p.node
 	p.node = p.node.Parent
+	return n
+}
+
+// RotateLeft moves the current node to the position it's parent had,
+// making the parent into the current node's child.
+func (p *Parser[V]) RotateLeft() *Node[V] {
+	// n = node , op = original parent , gp = grand parent
+	n := p.node
+	op := n.Parent
+	gp := op.Parent
+
+	// Remove n from op's Children
+	opChildren := op.Children[:0]
+	for _, x := range op.Children {
+		if x != n {
+			opChildren = append(opChildren, x)
+		}
+	}
+	op.Children = opChildren
+
+	// Add op to n's Children
+	n.Children = append(n.Children, op)
+
+	// Update op's Parent
+	op.Parent = n
+
+	// Update n's Parent
+	n.Parent = gp
+
+	// Replace op with n in gp's Children
+	if gp != nil {
+		gpChildren := gp.Children[:0]
+		for _, x := range gp.Children {
+			if x != op {
+				gpChildren = append(gpChildren, x)
+			} else {
+				gpChildren = append(gpChildren, n)
+			}
+		}
+		gp.Children = gpChildren
+	}
+
+	// Update the tree root if needed
+	if p.Tree().Root == op {
+		p.Tree().Root = n
+	}
+
+	return n
+}
+
+// AdoptSibling moves the current node's previous sibling into the node's child.
+func (p *Parser[V]) AdoptSibling() *Node[V] {
+	// n = node , op = original parent , s = sibling
+	n := p.node
+	op := n.Parent
+	var s *Node[V]
+
+	// Find the previous sibling
+	for _, x := range op.Children {
+		if x == n {
+			break
+		}
+		s = x
+	}
+
+	// Remove s from op's Children
+	opChildren := op.Children[:0]
+	for _, x := range op.Children {
+		if x != s {
+			opChildren = append(opChildren, x)
+		}
+	}
+	op.Children = opChildren
+
+	// Add s to n's Children
+	n.Children = append(n.Children, s)
+
+	// Update s's Parent
+	s.Parent = n
+
 	return n
 }

--- a/parser.go
+++ b/parser.go
@@ -27,13 +27,13 @@ var ErrMissingRequiredNode = errors.New("missing required node")
 // TODO(#459): Implement parser
 
 // Tree is the parse tree data structure.
-type Tree[V any] struct {
+type Tree[V comparable] struct {
 	// Root points to the root Node in the parse tree.
 	Root *Node[V]
 }
 
 // Node is the structure for a single node in the parse tree.
-type Node[V any] struct {
+type Node[V comparable] struct {
 	Parent   *Node[V]
 	Children []*Node[V]
 	Value    V
@@ -41,10 +41,10 @@ type Node[V any] struct {
 }
 
 // FIXME: Remove channel.
-type ParseFn[V any] func(context.Context, *Parser[V]) (ParseFn[V], error)
+type ParseFn[V comparable] func(context.Context, *Parser[V]) (ParseFn[V], error)
 
 // NewParser creates a new Parser that reads from the lexemes channel.
-func NewParser[V any](lexemes <-chan *Lexeme) *Parser[V] {
+func NewParser[V comparable](lexemes <-chan *Lexeme) *Parser[V] {
 	root := &Node[V]{}
 	p := &Parser[V]{
 		lexemes: lexemes,
@@ -57,7 +57,7 @@ func NewParser[V any](lexemes <-chan *Lexeme) *Parser[V] {
 }
 
 // Parser reads the lexemes produced by a Lexer and builds a parse tree.
-type Parser[V any] struct {
+type Parser[V comparable] struct {
 	lexemes <-chan *Lexeme
 
 	tree *Tree[V]

--- a/parser.go
+++ b/parser.go
@@ -40,7 +40,14 @@ type Node[V comparable] struct {
 	// TODO: Position,Line,Column in original input.
 }
 
-// FIXME: Remove channel.
+// ParseFn is the signature for the parsing function used to build the
+// parse tree from lexemes.  The parsing function is passed to
+// Parse().
+// There may be more than one parsing function used by a parser.  The
+// top-level function is passed to Parse().  A parsing function hands
+// parsing off to another function by returning a pointer to the other
+// function.  Parse() will continue calling returned functions until
+// nil is returned.
 type ParseFn[V comparable] func(context.Context, *Parser[V]) (ParseFn[V], error)
 
 // NewParser creates a new Parser that reads from the lexemes channel.

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,708 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lexparse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ianlewis/runeio"
+)
+
+var (
+	errTreeMismatchSize  = errors.New("trees have different number of nodes")
+	errTreeMismatchValue = errors.New("trees node values do not match")
+)
+
+const (
+	debugPrint = false
+	inputABC   = "A B C"
+)
+
+// compareTrees returns true if two trees are equivalent by comparing the
+// value of each node in both trees.
+func compareTrees[T any](tr1, tr2 *Tree[T]) (bool, error) {
+	ch1 := make(chan string)
+	ch2 := make(chan string)
+
+	go walkTree(tr1, ch1)
+	go walkTree(tr2, ch2)
+
+	for {
+		i1, more1 := <-ch1
+		i2, more2 := <-ch2
+
+		if more1 != more2 {
+			return false, errTreeMismatchSize
+		}
+		if !more1 {
+			break
+		}
+
+		if i1 != i2 {
+			return false, fmt.Errorf("node values: %q, %q, %w", i1, i2, errTreeMismatchValue)
+		}
+	}
+
+	return true, nil
+}
+
+// debugPrintTreeNodes walks tree nodes and prints a visualization of the tree
+// when debugPrint is true.
+func debugPrintTreeNodes[T any](n int, node *Node[T]) {
+	if !debugPrint {
+		return
+	}
+
+	log.Printf(strings.Repeat(" ", n)+"Value: %+v", node.Value)
+
+	for _, c := range node.Children {
+		debugPrintTreeNodes[T](n+1, c)
+	}
+}
+
+// testLexer creates and returns a lexer.
+func testLexer(t *testing.T, input string) <-chan *Lexeme {
+	t.Helper()
+
+	l := NewLexer(runeio.NewReader(strings.NewReader(input)), &wordState{})
+
+	return l.Lex(context.Background())
+}
+
+// testParse creates and runs a lexer, and returns the parse tree.
+func testParse(t *testing.T, input string) (*Tree[string], error) {
+	t.Helper()
+
+	lexemes := testLexer(t, input)
+
+	p := NewParser[string](lexemes)
+	pFn := func(_ context.Context, p *Parser[string]) (ParseFn[string], error) {
+		for {
+			lexeme := p.Next()
+			if lexeme == nil {
+				break
+			}
+
+			switch lexeme.Value {
+			case "op":
+				p.Push(lexeme.Value)
+			default:
+				p.Node(lexeme.Value)
+			}
+		}
+		return nil, nil
+	}
+
+	ctx := context.Background()
+	tree, err := p.Parse(ctx, pFn)
+	return tree, err
+}
+
+// walkTree walks a parse tree and sends a string value of each node to the channel.
+func walkTree[T any](tr *Tree[T], ch chan<- string) {
+	defer close(ch)
+
+	doWalkTree(ch, "", tr.Root)
+}
+
+// doWalkTree is a recursive worker function used by walkTree.
+func doWalkTree[T any](ch chan<- string, depth string, node *Node[T]) {
+	if node == nil {
+		return
+	}
+
+	message := ""
+	message += fmt.Sprintf(depth+":Value: %v", node.Value)
+	ch <- message
+
+	for i, c := range node.Children {
+		newDepth := depth + strconv.Itoa(i)
+		doWalkTree(ch, newDepth, c)
+	}
+}
+
+func TestParser_new(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	tree := p.Tree()
+	if tree == nil {
+		t.Errorf("tree should not be nil")
+	} else {
+		if tree.Root == nil {
+			t.Errorf("tree root should not be nil")
+		}
+		if tree.Root.Parent != nil {
+			t.Errorf("tree root parent should be nil")
+		}
+		if len(tree.Root.Children) != 0 {
+			t.Errorf("tree root should have no children")
+		}
+		if tree.Root.Value != "" {
+			t.Errorf("tree root value should be blank")
+		}
+	}
+}
+
+// TestParser_parse_op2 builds a tree of 2-child operations.
+func TestParser_parse_op2(t *testing.T) {
+	t.Parallel()
+
+	input := "op 1 op 2 3"
+
+	tree, err := testParse(t, input)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	debugPrintTreeNodes[string](0, tree.Root)
+
+	// Does the tree look as expected?
+
+	expectedTree := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "op",
+					Children: []*Node[string]{
+						{
+							Value: "1",
+						},
+						{
+							Value: "op",
+							Children: []*Node[string]{
+								{
+									Value: "2",
+								},
+								{
+									Value: "3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	debugPrintTreeNodes[string](0, expectedTree.Root)
+
+	got, expErr := compareTrees[string](tree, expectedTree)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want := true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	// Does checking the shape of the tree work as expected?
+
+	treeUnexpShape := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "op",
+					Children: []*Node[string]{
+						{
+							Value: "1",
+						},
+						{
+							Value: "op",
+						},
+						{
+							Value: "2",
+						},
+						{
+							Value: "3",
+						},
+					},
+				},
+			},
+		},
+	}
+	debugPrintTreeNodes[string](0, treeUnexpShape.Root)
+
+	got, unexpShpErr := compareTrees[string](tree, treeUnexpShape)
+	if unexpShpErr == nil {
+		t.Errorf("error unexpected trees match: %s", unexpShpErr)
+	}
+	want = false
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	// Does checking values in the the tree work as expected?
+
+	treeUnexpValue := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "op",
+					Children: []*Node[string]{
+						{
+							Value: "1",
+						},
+						{
+							Value: "op",
+							Children: []*Node[string]{
+								{
+									Value: "2",
+								},
+								{
+									Value: "4",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	debugPrintTreeNodes[string](0, treeUnexpValue.Root)
+
+	got, unexpValErr := compareTrees[string](tree, treeUnexpValue)
+	if unexpValErr == nil {
+		t.Errorf("error unexpected trees match: %s", unexpValErr)
+	}
+	want = false
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_AdoptSibling(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Push("op")
+	p.Node("1")
+	p.Node("2")
+	p.Push("foo")
+	tree1 := p.Tree()
+	debugPrintTreeNodes[string](0, tree1.Root)
+
+	expected1 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "op",
+					Children: []*Node[string]{
+						{
+							Value: "1",
+						},
+						{
+							Value: "2",
+						},
+						{
+							Value: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, expErr := compareTrees[string](tree1, expected1)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want := true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.AdoptSibling()
+	tree2 := p.Tree()
+	debugPrintTreeNodes[string](0, tree2.Root)
+
+	expected2 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "op",
+					Children: []*Node[string]{
+						{
+							Value: "1",
+						},
+						{
+							Value: "foo",
+							Children: []*Node[string]{
+								{
+									Value: "2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, expErr = compareTrees[string](tree2, expected2)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want = true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_NextPeek(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	// expect to read the first lexeme "A"
+	lexeme1 := p.Next()
+	if lexeme1 == nil {
+		t.Errorf("lexeme should not be nil")
+	} else {
+		got := lexeme1.Value
+		want := "A"
+		if got != want {
+			t.Errorf("lexeme match: want: %v, got: %v", want, got)
+		}
+	}
+
+	// expect to peek at second lexeme "B" without consuming it
+	lexeme2 := p.Peek()
+	if lexeme2 == nil {
+		t.Errorf("lexeme should not be nil")
+	} else {
+		got := lexeme2.Value
+		want := "B"
+		if got != want {
+			t.Errorf("lexeme match: want: %v, got: %v", want, got)
+		}
+	}
+
+	// expect to read the second lexeme "B" because it was not consumed
+	lexeme3 := p.Next()
+	if lexeme3 == nil {
+		t.Errorf("lexeme should not be nil")
+	} else {
+		got := lexeme3.Value
+		want := "B"
+		if got != want {
+			t.Errorf("lexeme match: want: %v, got: %v", want, got)
+		}
+	}
+
+	// expect to read the last lexeme "C"
+	lexeme4 := p.Next()
+	if lexeme4 == nil {
+		t.Errorf("lexeme should not be nil")
+	} else {
+		got := lexeme4.Value
+		want := "C"
+		if got != want {
+			t.Errorf("lexeme match: want: %v, got: %v", want, got)
+		}
+	}
+
+	// expected end of lexemes
+	lexeme5 := p.Next()
+	if lexeme5 != nil {
+		t.Errorf("lexeme should be nil")
+	}
+}
+
+func TestParser_Node(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Node("1")
+	tree1 := p.Tree()
+	debugPrintTreeNodes[string](0, tree1.Root)
+
+	expected1 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "1",
+				},
+			},
+		},
+	}
+
+	got, expErr := compareTrees[string](tree1, expected1)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want := true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.Node("2")
+	tree2 := p.Tree()
+	debugPrintTreeNodes[string](0, tree2.Root)
+
+	expected2 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "1",
+				},
+				{
+					Value: "2",
+				},
+			},
+		},
+	}
+
+	got, expErr = compareTrees[string](tree2, expected2)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want = true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_Pop(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Push("1")
+	p.Pop()
+	p.Push("2")
+	p.Pop()
+	p.Push("3")
+	tree1 := p.Tree()
+	debugPrintTreeNodes[string](0, tree1.Root)
+
+	expected1 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "1",
+				},
+				{
+					Value: "2",
+				},
+				{
+					Value: "3",
+				},
+			},
+		},
+	}
+
+	got, expErr := compareTrees[string](tree1, expected1)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want := true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_Pos(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Push("1")
+	got := p.Pos().Value
+	want := "1"
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.Push("2")
+	got = p.Pos().Value
+	want = "2"
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.Push("3")
+	got = p.Pos().Value
+	want = "3"
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.Pop()
+	got = p.Pos().Value
+	want = "2"
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_Push(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Push("1")
+	tree1 := p.Tree()
+
+	expected1 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "1",
+				},
+			},
+		},
+	}
+
+	got, expErr := compareTrees[string](tree1, expected1)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want := true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.Push("2")
+	tree2 := p.Tree()
+
+	expected2 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "1",
+					Children: []*Node[string]{
+						{
+							Value: "2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, expErr = compareTrees[string](tree2, expected2)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want = true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_RotateLeft(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Push("op")
+	p.Node("1")
+	p.Node("2")
+	tree1 := p.Tree()
+	debugPrintTreeNodes[string](0, tree1.Root)
+
+	expected1 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "op",
+					Children: []*Node[string]{
+						{
+							Value: "1",
+						},
+						{
+							Value: "2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, expErr := compareTrees[string](tree1, expected1)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want := true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+
+	p.Push("foo")
+	p.RotateLeft()
+	p.Node("3")
+	tree2 := p.Tree()
+	debugPrintTreeNodes[string](0, tree2.Root)
+
+	expected2 := &Tree[string]{
+		Root: &Node[string]{
+			Children: []*Node[string]{
+				{
+					Value: "foo",
+					Children: []*Node[string]{
+						{
+							Value: "op",
+							Children: []*Node[string]{
+								{
+									Value: "1",
+								},
+								{
+									Value: "2",
+								},
+							},
+						},
+						{
+							Value: "3",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, expErr = compareTrees[string](tree2, expected2)
+	if expErr != nil {
+		t.Errorf("error expected trees do not match: %s", expErr)
+	}
+	want = true
+	if got != want {
+		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -335,7 +335,16 @@ func TestParser_AdoptSibling(t *testing.T) {
 		t.Errorf("trees match: want: %v, got: %v", want, got)
 	}
 
-	p.AdoptSibling()
+	adoptNode, adoptErr := p.AdoptSibling()
+	wantNode := p.Pos()
+	var wantErr error
+	if adoptNode != wantNode {
+		t.Errorf("AdoptSibling node: want: %v, got: %v", wantNode, adoptNode)
+	}
+	if !errors.Is(adoptErr, wantErr) {
+		t.Errorf("AdoptSibling err: want: %v, got: %v", wantErr, adoptErr)
+	}
+
 	tree2 := p.Tree()
 	debugPrintTreeNodes[string](0, tree2.Root)
 
@@ -369,6 +378,45 @@ func TestParser_AdoptSibling(t *testing.T) {
 	want = true
 	if got != want {
 		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_AdoptSibling_empty(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	gotNode, gotErr := p.AdoptSibling()
+	var wantNode *Node[string]
+	wantErr := ErrMissingRequiredNode
+	if gotNode != wantNode {
+		t.Errorf("empty tree AdoptSibling node: want: %v, got: %v", wantNode, gotNode)
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Errorf("empty tree AdoptSibling err: want: %v, got: %v", wantErr, gotErr)
+	}
+}
+
+func TestParser_AdoptSibling_notfound(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	p.Push("op")
+	p.Push("foo")
+
+	gotNode, gotErr := p.AdoptSibling()
+	var wantNode *Node[string]
+	wantErr := ErrMissingRequiredNode
+	if gotNode != wantNode {
+		t.Errorf("no sibling AdoptSibling node: want: %v, got: %v", wantNode, gotNode)
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Errorf("no sibling AdoptSibling err: want: %v, got: %v", wantErr, gotErr)
 	}
 }
 
@@ -666,7 +714,16 @@ func TestParser_RotateLeft(t *testing.T) {
 	}
 
 	p.Push("foo")
-	p.RotateLeft()
+	rotNode, rotErr := p.RotateLeft()
+	wantNode := p.Pos()
+	var wantErr error
+	if rotNode != wantNode {
+		t.Errorf("RotateLeft node: want: %v, got: %v", wantNode, rotNode)
+	}
+	if !errors.Is(rotErr, wantErr) {
+		t.Errorf("RotateLeft err: want: %v, got: %v", wantErr, rotErr)
+	}
+
 	p.Node("3")
 	tree2 := p.Tree()
 	debugPrintTreeNodes[string](0, tree2.Root)
@@ -704,5 +761,23 @@ func TestParser_RotateLeft(t *testing.T) {
 	want = true
 	if got != want {
 		t.Errorf("trees match: want: %v, got: %v", want, got)
+	}
+}
+
+func TestParser_RotateLeft_empty(t *testing.T) {
+	t.Parallel()
+
+	input := inputABC
+	lexemes := testLexer(t, input)
+	p := NewParser[string](lexemes)
+
+	gotNode, gotErr := p.RotateLeft()
+	var wantNode *Node[string]
+	wantErr := ErrMissingRequiredNode
+	if gotNode != wantNode {
+		t.Errorf("empty tree RotateLeft node: want: %v, got: %v", wantNode, gotNode)
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Errorf("empty tree RotateLeft err: want: %v, got: %v", wantErr, gotErr)
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -58,9 +58,9 @@ func doCompareTrees[T comparable](n1, n2 *Node[T]) (bool, error) {
 		return false, errTreeMismatchSize
 	}
 	for i := range n1.Children {
-		b, e := doCompareTrees(n1.Children[i], n2.Children[i])
-		if b != true || e != nil {
-			return b, e
+		b, err := doCompareTrees(n1.Children[i], n2.Children[i])
+		if b != true || err != nil {
+			return b, err
 		}
 	}
 


### PR DESCRIPTION
- lint fixes in `parser.go`.
- Added Parser test cases in `parser_test.go`.
- Added two functions to move nodes around in a parse tree.

1. `RotateLeft()` is used to move the current node into the position of it's parent.   This is useful to make the input `1 - 2 - 3` be parsed as `(1 - 2) - 3` instead of as `1 - (2 - 3)`.  Before calling `RotateLeft()` the tree wold look like:
```
'-' (first '-')
  '1'
  '2'
  '-' (second '-')
```
After:
```
'-' (second '-')
  '-' (first '-')
    '1'
    '2'
 ```
Then adding '3' produces:
```
'-' (second '-')
  '-' (first '-')
    '1'
    '2'
  '3'
 ```

2. `AdoptSibling()` is used to move the current node's previous sibling from the parent's children to the current node's children.  This is useful for input with more than one operator in a row like `1 + 2 * 3`.  Before calling `AdoptSibling()` the tree would look like:
```
'+'
  '1'
  '2'
  '*'
```
After:
```
'+'
  '1'
  '*'
    '2'
```
Then adding '3' produces:
```
'+'
  '1'
  '*'
    '2'
    '3'
```