### PR TITLE
feat: Use 1-based indexing

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -39,7 +39,6 @@ const (
 var (
 	errType           = errors.New("unexpected type")
 	errUnclosedAction = errors.New("unclosed action")
-	errSymbol         = errors.New("invalid symbol")
 )
 
 type nodeType int
@@ -181,7 +180,7 @@ func execute(root *lexparse.Node[*tmplNode], data map[string]string) (string, er
 			// Replace templated variables with given data.
 			val, ok := data[n.Value.action]
 			if !ok {
-				return b.String(), fmt.Errorf("%w: %q at line %d, column %d", errSymbol, n.Value.action, n.Line+1, n.Column+1)
+				val = ""
 			}
 			b.WriteString(val)
 		}

--- a/lexer.go
+++ b/lexer.go
@@ -85,10 +85,10 @@ type Lexeme struct {
 	// Pos is the position in the byte stream where the Lexeme was found.
 	Pos int
 
-	// Line is the line number where the Lexeme was found.
+	// Line is the line number where the Lexeme was found (one-based).
 	Line int
 
-	// Column is the column in the line where the Lexeme was found.
+	// Column is the column in the line where the Lexeme was found (one-based).
 	Column int
 }
 
@@ -161,18 +161,18 @@ func (l *Lexer) Pos() int {
 	return pos
 }
 
-// Line returns the current line in the input (zero indexed).
+// Line returns the current line in the input (one-based).
 func (l *Lexer) Line() int {
 	l.s.Lock()
-	line := l.s.line
+	line := l.s.line + 1
 	l.s.Unlock()
 	return line
 }
 
-// Column returns the current column in the input (zero indexed).
+// Column returns the current column in the input (one-based).
 func (l *Lexer) Column() int {
 	l.s.Lock()
-	c := l.s.column
+	c := l.s.column + 1
 	l.s.Unlock()
 	return c
 }
@@ -465,8 +465,8 @@ func (l *Lexer) Lexeme(typ LexemeType) *Lexeme {
 		Type:   typ,
 		Value:  l.s.b.String(),
 		Pos:    l.s.startPos,
-		Line:   l.s.startLine,
-		Column: l.s.startColumn,
+		Line:   l.s.startLine + 1,
+		Column: l.s.startColumn + 1,
 	}
 	l.s.Unlock()
 	return lexeme

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -79,11 +79,11 @@ func TestLexer_Peek(t *testing.T) {
 		t.Errorf("Pos: want: %v, got: %v", want, got)
 	}
 
-	if got, want := l.Line(), 0; got != want {
+	if got, want := l.Line(), 1; got != want {
 		t.Errorf("Line: want: %v, got: %v", want, got)
 	}
 
-	if got, want := l.Column(), 0; got != want {
+	if got, want := l.Column(), 1; got != want {
 		t.Errorf("Column: want: %v, got: %v", want, got)
 	}
 
@@ -128,11 +128,11 @@ func TestLexer_Advance(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 1; got != want {
+		if got, want := l.Column(), 2; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -144,11 +144,11 @@ func TestLexer_Advance(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 0; got != want {
+		if got, want := lexeme.Line, 1; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 0; got != want {
+		if got, want := lexeme.Column, 1; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -170,11 +170,11 @@ func TestLexer_Advance(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 9; got != want {
+		if got, want := l.Column(), 10; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -186,11 +186,11 @@ func TestLexer_Advance(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 0; got != want {
+		if got, want := lexeme.Line, 1; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 0; got != want {
+		if got, want := lexeme.Column, 1; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -224,11 +224,11 @@ func TestLexer_Discard(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 1; got != want {
+		if got, want := l.Column(), 2; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -240,11 +240,11 @@ func TestLexer_Discard(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 1; got != want {
+		if got, want := lexeme.Line, 2; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 1; got != want {
+		if got, want := lexeme.Column, 2; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -266,11 +266,11 @@ func TestLexer_Discard(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 9; got != want {
+		if got, want := l.Column(), 10; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -282,11 +282,11 @@ func TestLexer_Discard(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 1; got != want {
+		if got, want := lexeme.Line, 2; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 9; got != want {
+		if got, want := lexeme.Column, 10; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -320,11 +320,11 @@ func TestLexer_Find(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 1; got != want {
+		if got, want := l.Column(), 2; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -336,11 +336,11 @@ func TestLexer_Find(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 0; got != want {
+		if got, want := lexeme.Line, 1; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 0; got != want {
+		if got, want := lexeme.Column, 1; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -362,11 +362,11 @@ func TestLexer_Find(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 6; got != want {
+		if got, want := l.Column(), 7; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -378,11 +378,11 @@ func TestLexer_Find(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 0; got != want {
+		if got, want := lexeme.Line, 1; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 0; got != want {
+		if got, want := lexeme.Column, 1; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -416,11 +416,11 @@ func TestLexer_Ignore(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 1; got != want {
+		if got, want := l.Column(), 2; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -446,11 +446,11 @@ func TestLexer_Ignore(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 8; got != want {
+		if got, want := l.Column(), 9; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -462,11 +462,11 @@ func TestLexer_Ignore(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 1; got != want {
+		if got, want := lexeme.Line, 2; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 1; got != want {
+		if got, want := lexeme.Column, 2; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -500,11 +500,11 @@ func TestLexer_SkipTo(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 1; got != want {
+		if got, want := l.Column(), 2; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -516,11 +516,11 @@ func TestLexer_SkipTo(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 1; got != want {
+		if got, want := lexeme.Line, 2; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 1; got != want {
+		if got, want := lexeme.Column, 2; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -542,11 +542,11 @@ func TestLexer_SkipTo(t *testing.T) {
 			t.Errorf("Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Line(), 1; got != want {
+		if got, want := l.Line(), 2; got != want {
 			t.Errorf("Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := l.Column(), 6; got != want {
+		if got, want := l.Column(), 7; got != want {
 			t.Errorf("Column: want: %v, got: %v", want, got)
 		}
 
@@ -558,11 +558,11 @@ func TestLexer_SkipTo(t *testing.T) {
 			t.Errorf("lexeme.Pos: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Line, 1; got != want {
+		if got, want := lexeme.Line, 2; got != want {
 			t.Errorf("lexeme.Line: want: %v, got: %v", want, got)
 		}
 
-		if got, want := lexeme.Column, 6; got != want {
+		if got, want := lexeme.Column, 7; got != want {
 			t.Errorf("lexeme.Column: want: %v, got: %v", want, got)
 		}
 	})
@@ -584,15 +584,15 @@ func TestLexer_lexemes(t *testing.T) {
 			Type:   wordType,
 			Value:  "Hello",
 			Pos:    0,
-			Line:   0,
-			Column: 0,
+			Line:   1,
+			Column: 1,
 		},
 		{
 			Type:   wordType,
 			Value:  "Lexemes!",
 			Pos:    6,
-			Line:   0,
-			Column: 6,
+			Line:   1,
+			Column: 7,
 		},
 	}
 	err := l.Err()

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -66,14 +66,14 @@ func TestLexParse(t *testing.T) {
 		expectedRoot := newTree(
 			&Node[string]{
 				Value:  "Hello",
-				Line:   0,
-				Column: 0,
+				Line:   1,
+				Column: 1,
 				Pos:    0,
 			},
 			&Node[string]{
 				Value:  "World!",
-				Line:   1,
-				Column: 0,
+				Line:   2,
+				Column: 1,
 				Pos:    6,
 			},
 		)

--- a/parser_test.go
+++ b/parser_test.go
@@ -114,32 +114,32 @@ func TestParser_parse_op2(t *testing.T) {
 	// Does the tree look as expected?
 	expectedRoot := newTree(&Node[string]{
 		Value:  "push",
-		Line:   0,
-		Column: 0,
+		Line:   1,
+		Column: 1,
 		Pos:    0,
 		Children: []*Node[string]{
 			{
 				Value:  "1",
-				Line:   0,
-				Column: 5,
+				Line:   1,
+				Column: 6,
 				Pos:    5,
 			},
 			{
 				Value:  "push",
-				Line:   0,
-				Column: 7,
+				Line:   1,
+				Column: 8,
 				Pos:    7,
 				Children: []*Node[string]{
 					{
 						Value:  "2",
-						Line:   0,
-						Column: 12,
+						Line:   1,
+						Column: 13,
 						Pos:    12,
 					},
 					{
 						Value:  "3",
-						Line:   0,
-						Column: 14,
+						Line:   1,
+						Column: 15,
 						Pos:    14,
 					},
 				},
@@ -167,8 +167,8 @@ func TestParser_NextPeek(t *testing.T) {
 		Type:   wordType,
 		Value:  "A",
 		Pos:    0,
-		Line:   0,
-		Column: 0,
+		Line:   1,
+		Column: 1,
 	}
 	if diff := cmp.Diff(wantLexemeA, lexemeA); diff != "" {
 		t.Fatalf("Next: (-want, +got): \n%s", diff)
@@ -179,8 +179,8 @@ func TestParser_NextPeek(t *testing.T) {
 		Type:   wordType,
 		Value:  "B",
 		Pos:    2,
-		Line:   0,
-		Column: 2,
+		Line:   1,
+		Column: 3,
 	}
 	if diff := cmp.Diff(wantLexemeB, peekLexemeB); diff != "" {
 		t.Fatalf("Peek: (-want, +got): \n%s", diff)
@@ -197,8 +197,8 @@ func TestParser_NextPeek(t *testing.T) {
 		Type:   wordType,
 		Value:  "C",
 		Pos:    4,
-		Line:   0,
-		Column: 4,
+		Line:   1,
+		Column: 5,
 	}
 	if diff := cmp.Diff(wantLexemeC, lexemeC); diff != "" {
 		t.Fatalf("Next: (-want, +got): \n%s", diff)


### PR DESCRIPTION
**Description:**

Use one-based indexing for the line and column of lexemes as this is more user friendly (e.g. for error messages) and more intuitive.

**Related Issues:**

Fixes #81 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
