### PR TITLE
chore: Rename Lexeme to Token

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	unusedType LexemeType = iota
+	unusedType TokenType = iota
 	wordType
 )
 
@@ -91,15 +91,15 @@ func TestLexer_Peek(t *testing.T) {
 		t.Errorf("Column: want: %v, got: %v", want, got)
 	}
 
-	if got, want := l.s.startPos, 0; got != want {
+	if got, want := l.startPos, 0; got != want {
 		t.Errorf("startPos: want: %v, got: %v", want, got)
 	}
 
-	if got, want := l.s.startLine, 0; got != want {
+	if got, want := l.startLine, 0; got != want {
 		t.Errorf("startLine: want: %v, got: %v", want, got)
 	}
 
-	if got, want := l.s.startColumn, 0; got != want {
+	if got, want := l.startColumn, 0; got != want {
 		t.Errorf("startColumn: want: %v, got: %v", want, got)
 	}
 }
@@ -548,21 +548,21 @@ func TestLexer_SkipTo(t *testing.T) {
 	})
 }
 
-func TestLexer_lexemes(t *testing.T) {
+func TestLexer_tokens(t *testing.T) {
 	t.Parallel()
 
-	lexemes := make(chan *Lexeme, 1024)
-	l := NewLexer(runeio.NewReader(strings.NewReader("Hello Lexemes!")), lexemes, &lexWordState{})
+	tokens := make(chan *Token, 1024)
+	l := NewLexer(runeio.NewReader(strings.NewReader("Hello tokens!")), tokens, &lexWordState{})
 	if err := l.Lex(context.Background()); err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	var items []*Lexeme
-	for item := range lexemes {
+	var items []*Token
+	for item := range tokens {
 		items = append(items, item)
 	}
 	got := items
-	want := []*Lexeme{
+	want := []*Token{
 		{
 			Type:   wordType,
 			Value:  "Hello",
@@ -572,7 +572,7 @@ func TestLexer_lexemes(t *testing.T) {
 		},
 		{
 			Type:   wordType,
-			Value:  "Lexemes!",
+			Value:  "tokens!",
 			Pos:    6,
 			Line:   1,
 			Column: 7,

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -66,9 +66,9 @@ func TestLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		lexemes := make(chan *Lexeme, 1024)
-		lexer := NewLexer(r, lexemes, &lexWordState{})
-		parser := NewParser[string](lexemes, &parseWordState{})
+		tokens := make(chan *Token, 1024)
+		lexer := NewLexer(r, tokens, &lexWordState{})
+		parser := NewParser[string](tokens, &parseWordState{})
 
 		got, err := LexParse(ctx, lexer, parser)
 		if err != nil {
@@ -104,9 +104,9 @@ func TestLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		lexemes := make(chan *Lexeme, 1024)
-		lexer := NewLexer(r, lexemes, &lexErrState{})
-		parser := NewParser[string](lexemes, &parseErrState{})
+		tokens := make(chan *Token, 1024)
+		lexer := NewLexer(r, tokens, &lexErrState{})
+		parser := NewParser[string](tokens, &parseErrState{})
 
 		_, got := LexParse(ctx, lexer, parser)
 		want := errState
@@ -124,9 +124,9 @@ func TestLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		lexemes := make(chan *Lexeme, 1024)
-		lexer := NewLexer(r, lexemes, &lexWordState{})
-		parser := NewParser[string](lexemes, &parseErrState{})
+		tokens := make(chan *Token, 1024)
+		lexer := NewLexer(r, tokens, &lexWordState{})
+		parser := NewParser[string](tokens, &parseErrState{})
 
 		_, got := LexParse(ctx, lexer, parser)
 		want := errParse

--- a/template_example_test.go
+++ b/template_example_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	lexTypeText lexparse.LexemeType = iota
+	lexTypeText lexparse.TokenType = iota
 	lexTypeBlockStart
 	lexTypeBlockEnd
 	lexTypeVarStart
@@ -80,7 +80,7 @@ type tmplNode struct {
 	text    string
 }
 
-func tokenErr(err error, t *lexparse.Lexeme) error {
+func tokenErr(err error, t *lexparse.Token) error {
 	return fmt.Errorf("%w: %q: line: %d, column: %d", err, t.Value, t.Line, t.Column)
 }
 
@@ -182,7 +182,7 @@ func parseRoot(_ context.Context, p *lexparse.Parser[*tmplNode]) error {
 	return nil
 }
 
-// parseCode delegates to another parse function based on lexeme type.
+// parseCode delegates to another parse function based on token type.
 func parseCode(_ context.Context, p *lexparse.Parser[*tmplNode]) error {
 	fmt.Fprintf(os.Stderr, "parseCode: %#v\n", p.Pos().Value)
 
@@ -217,7 +217,7 @@ func parseCode(_ context.Context, p *lexparse.Parser[*tmplNode]) error {
 func parseText(_ context.Context, p *lexparse.Parser[*tmplNode]) error {
 	fmt.Fprintf(os.Stderr, "parseText: %#v\n", p.Pos().Value)
 
-	// Get the next lexeme from the parser.
+	// Get the next token from the parser.
 	l := p.Next()
 	// TODO(#95): Remove nil check.
 	if l == nil {
@@ -568,13 +568,13 @@ func execNode(root *lexparse.Node[*tmplNode], data map[string]string, b *strings
 // This example includes some best practices for error handling, such as
 // including line and column numbers in error messages.
 func Example_templateEngine() {
-	lexemes := make(chan *lexparse.Lexeme, 1024)
+	tokens := make(chan *lexparse.Token, 1024)
 	r := runeio.NewReader(strings.NewReader("Hello, {% if subject %}{{ subject }}{% else %}World{% endif %}!"))
 
 	t, err := lexparse.LexParse(
 		context.Background(),
-		lexparse.NewLexer(r, lexemes, lexparse.LexStateFn(lexText)),
-		lexparse.NewParser(lexemes, lexparse.ParseStateFn(parseRoot)),
+		lexparse.NewLexer(r, tokens, lexparse.LexStateFn(lexText)),
+		lexparse.NewParser(tokens, lexparse.ParseStateFn(parseRoot)),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**Description:**

Rename the `Lexeme` type to `Token` to make it clearer to understand.

**Related Issues:**

Fixes #96

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
