### PR TITLE
refactor: Update API around EOF token

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -16,8 +16,6 @@ package lexparse
 
 import (
 	"context"
-	"errors"
-	"io"
 	"strings"
 	"testing"
 	"unicode"
@@ -27,29 +25,23 @@ import (
 )
 
 const (
-	unusedType TokenType = iota
-	wordType
+	wordType TokenType = iota + 1
 )
 
 type lexWordState struct{}
 
 func (w *lexWordState) Run(_ context.Context, l *Lexer) (LexState, error) {
-	rn, err := l.Peek(1)
-	if errors.Is(err, io.EOF) || (err == nil && unicode.IsSpace(rn[0])) {
+	rn := l.Peek()
+	if unicode.IsSpace(rn) || rn == EOF {
 		// NOTE: This can emit empty words.
 		l.Emit(wordType)
 		// Discard the space
-		if _, dErr := l.Discard(len(rn)); dErr != nil {
-			return nil, dErr
+		if !l.Discard() {
+			return nil, nil
 		}
 	}
-	if err != nil {
-		return nil, err
-	}
 
-	if _, aErr := l.Advance(len(rn)); aErr != nil {
-		return nil, aErr
-	}
+	l.Advance()
 
 	return w, nil
 }
@@ -59,16 +51,58 @@ func TestLexer_Peek(t *testing.T) {
 
 	l := NewLexer(runeio.NewReader(strings.NewReader("Hello\nWorld!")), nil, &lexWordState{})
 
-	rns, err := l.Peek(6)
-	if err != nil {
+	rn := l.Peek()
+	if err := l.Err(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got, want := rn, 'H'; got != want {
+		t.Errorf("Peek: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Pos(), 0; got != want {
+		t.Errorf("Pos: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Cursor(), 0; got != want {
+		t.Errorf("Cursor: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Line(), 1; got != want {
+		t.Errorf("Line: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Column(), 1; got != want {
+		t.Errorf("Column: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.startPos, 0; got != want {
+		t.Errorf("startPos: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.startLine, 0; got != want {
+		t.Errorf("startLine: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.startColumn, 0; got != want {
+		t.Errorf("startColumn: want: %v, got: %v", want, got)
+	}
+}
+
+func TestLexer_PeekN(t *testing.T) {
+	t.Parallel()
+
+	l := NewLexer(runeio.NewReader(strings.NewReader("Hello\nWorld!")), nil, &lexWordState{})
+
+	rns := l.PeekN(6)
+	if err := l.Err(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if got, want := string(rns), "Hello\n"; got != want {
 		t.Errorf("Peek: want: %q, got: %q", want, got)
 	}
 
-	rns, err = l.Peek(16)
-	if !errors.Is(err, io.EOF) {
+	rns = l.PeekN(16)
+	if err := l.Err(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if got, want := string(rns), "Hello\nWorld!"; got != want {
@@ -107,21 +141,109 @@ func TestLexer_Peek(t *testing.T) {
 func TestLexer_Advance(t *testing.T) {
 	t.Parallel()
 
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Advance!")), nil, &lexWordState{})
+
+		advanced := l.Advance()
+		if err := l.Err(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got, want := advanced, true; got != want {
+			t.Errorf("Advance: want: %v, got: %v", want, got)
+		}
+
+		rns := l.PeekN(10)
+		if err := l.Err(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got, want := string(rns), "ello\n!Adva"; got != want {
+			t.Errorf("PeekN: want: %q, got: %q", want, got)
+		}
+
+		if got, want := l.Pos(), 1; got != want {
+			t.Errorf("Pos: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Cursor(), 0; got != want {
+			t.Errorf("Cursor: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Line(), 1; got != want {
+			t.Errorf("Line: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Column(), 2; got != want {
+			t.Errorf("Column: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Width(), 1; got != want {
+			t.Errorf("Width: want: %q, got: %q", want, got)
+		}
+
+		if got, want := l.Token(), "H"; got != want {
+			t.Errorf("Token: want: %q, got: %q", want, got)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewLexer(runeio.NewReader(strings.NewReader("")), nil, &lexWordState{})
+
+		advanced := l.Advance()
+		if err := l.Err(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got, want := advanced, false; got != want {
+			t.Errorf("Advance: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Pos(), 0; got != want {
+			t.Errorf("Pos: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Cursor(), 0; got != want {
+			t.Errorf("Cursor: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Line(), 1; got != want {
+			t.Errorf("Line: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Column(), 1; got != want {
+			t.Errorf("Column: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Width(), 0; got != want {
+			t.Errorf("Width: want: %q, got: %q", want, got)
+		}
+
+		if got, want := l.Token(), ""; got != want {
+			t.Errorf("Token: want: %q, got: %q", want, got)
+		}
+	})
+}
+
+func TestLexer_AdvanceN(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic", func(t *testing.T) {
 		t.Parallel()
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Advance!")), nil, &lexWordState{})
 
-		advanced, err := l.Advance(5)
-		if err != nil {
+		advanced := l.AdvanceN(5)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := advanced, 5; got != want {
 			t.Errorf("Advance: want: %v, got: %v", want, got)
 		}
 
-		rns, err := l.Peek(10)
-		if err != nil {
+		rns := l.PeekN(10)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := string(rns), "\n!Advance!"; got != want {
@@ -158,8 +280,8 @@ func TestLexer_Advance(t *testing.T) {
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Advance!")), nil, &lexWordState{})
 
-		advanced, err := l.Advance(16)
-		if !errors.Is(err, io.EOF) {
+		advanced := l.AdvanceN(16)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := advanced, 15; got != want {
@@ -195,21 +317,109 @@ func TestLexer_Advance(t *testing.T) {
 func TestLexer_Discard(t *testing.T) {
 	t.Parallel()
 
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Advance!")), nil, &lexWordState{})
+
+		discarded := l.Discard()
+		if err := l.Err(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got, want := discarded, true; got != want {
+			t.Errorf("Discard: want: %v, got: %v", want, got)
+		}
+
+		rns := l.PeekN(10)
+		if err := l.Err(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got, want := string(rns), "ello\n!Adva"; got != want {
+			t.Errorf("PeekN: want: %q, got: %q", want, got)
+		}
+
+		if got, want := l.Pos(), 1; got != want {
+			t.Errorf("Pos: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Cursor(), 1; got != want {
+			t.Errorf("Cursor: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Line(), 1; got != want {
+			t.Errorf("Line: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Column(), 2; got != want {
+			t.Errorf("Column: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Width(), 0; got != want {
+			t.Errorf("Width: want: %q, got: %q", want, got)
+		}
+
+		if got, want := l.Token(), ""; got != want {
+			t.Errorf("Token: want: %q, got: %q", want, got)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewLexer(runeio.NewReader(strings.NewReader("")), nil, &lexWordState{})
+
+		discarded := l.Discard()
+		if err := l.Err(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got, want := discarded, false; got != want {
+			t.Errorf("Discard: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Pos(), 0; got != want {
+			t.Errorf("Pos: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Cursor(), 0; got != want {
+			t.Errorf("Cursor: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Line(), 1; got != want {
+			t.Errorf("Line: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Column(), 1; got != want {
+			t.Errorf("Column: want: %v, got: %v", want, got)
+		}
+
+		if got, want := l.Width(), 0; got != want {
+			t.Errorf("Width: want: %q, got: %q", want, got)
+		}
+
+		if got, want := l.Token(), ""; got != want {
+			t.Errorf("Token: want: %q, got: %q", want, got)
+		}
+	})
+}
+
+func TestLexer_DiscardN(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic", func(t *testing.T) {
 		t.Parallel()
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Discard!")), nil, &lexWordState{})
 
-		discarded, err := l.Discard(7)
-		if err != nil {
+		discarded := l.DiscardN(7)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := discarded, 7; got != want {
 			t.Errorf("Discard: want: %v, got: %v", want, got)
 		}
 
-		rns, err := l.Peek(8)
-		if err != nil {
+		rns := l.PeekN(8)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := string(rns), "Discard!"; got != want {
@@ -246,8 +456,8 @@ func TestLexer_Discard(t *testing.T) {
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Discard!")), nil, &lexWordState{})
 
-		discarded, err := l.Discard(16)
-		if !errors.Is(err, io.EOF) {
+		discarded := l.DiscardN(16)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := discarded, 15; got != want {
@@ -280,92 +490,129 @@ func TestLexer_Discard(t *testing.T) {
 	})
 }
 
-func TestLexer_Find(t *testing.T) {
+func TestLexer_Find_match(t *testing.T) {
 	t.Parallel()
 
-	t.Run("match", func(t *testing.T) {
-		t.Parallel()
+	l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
 
-		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
+	token := l.Find([]string{"Find"})
+	if err := l.Err(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got, want := token, "Find"; got != want {
+		t.Errorf("unexpected token: want: %q, got: %q", want, got)
+	}
 
-		token, err := l.Find([]string{"Find"})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if got, want := token, "Find"; got != want {
-			t.Errorf("unexpected token: want: %q, got: %q", want, got)
-		}
+	rns := l.PeekN(5)
+	if err := l.Err(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
-		rns, err := l.Peek(5)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if got, want := string(rns), "Find!"; got != want {
-			t.Errorf("Peek: want: %q, got: %q", want, got)
-		}
+	//nolint:goconst // It's easier to understand the test if the string is written out.
+	if got, want := string(rns), "Find!"; got != want {
+		t.Errorf("Peek: want: %q, got: %q", want, got)
+	}
 
-		if got, want := l.Pos(), 7; got != want {
-			t.Errorf("Pos: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Pos(), 7; got != want {
+		t.Errorf("Pos: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Cursor(), 0; got != want {
-			t.Errorf("Cursor: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Cursor(), 0; got != want {
+		t.Errorf("Cursor: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Line(), 2; got != want {
-			t.Errorf("Line: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Line(), 2; got != want {
+		t.Errorf("Line: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Column(), 2; got != want {
-			t.Errorf("Column: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Column(), 2; got != want {
+		t.Errorf("Column: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Width(), 7; got != want {
-			t.Errorf("Width: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Width(), 7; got != want {
+		t.Errorf("Width: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Token(), "Hello\n!"; got != want {
-			t.Errorf("Token: want: %q, got: %q", want, got)
-		}
-	})
+	//nolint:goconst // It's easier to understand the test if the string is written out.
+	if got, want := l.Token(), "Hello\n!"; got != want {
+		t.Errorf("Token: want: %q, got: %q", want, got)
+	}
+}
 
-	t.Run("no match", func(t *testing.T) {
-		t.Parallel()
+func TestLexer_Find_short_match(t *testing.T) {
+	t.Parallel()
 
-		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
+	l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
 
-		token, err := l.Find([]string{"no match"})
-		if !errors.Is(err, io.EOF) {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if got, want := token, ""; got != want {
-			t.Errorf("unexpected token: want: %q, got: %q", want, got)
-		}
+	token := l.Find([]string{"no match", "Find!"})
+	if err := l.Err(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got, want := token, "Find!"; got != want {
+		t.Errorf("unexpected token: want: %q, got: %q", want, got)
+	}
 
-		if got, want := l.Pos(), 12; got != want {
-			t.Errorf("Pos: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Pos(), 7; got != want {
+		t.Errorf("Pos: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Cursor(), 0; got != want {
-			t.Errorf("Cursor: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Cursor(), 0; got != want {
+		t.Errorf("Cursor: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Line(), 2; got != want {
-			t.Errorf("Line: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Line(), 2; got != want {
+		t.Errorf("Line: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Column(), 7; got != want {
-			t.Errorf("Column: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Column(), 2; got != want {
+		t.Errorf("Column: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Width(), 12; got != want {
-			t.Errorf("Width: want: %v, got: %v", want, got)
-		}
+	if got, want := l.Width(), 7; got != want {
+		t.Errorf("Width: want: %v, got: %v", want, got)
+	}
 
-		if got, want := l.Token(), "Hello\n!Find!"; got != want {
-			t.Errorf("Token: want: %q, got: %q", want, got)
-		}
-	})
+	if got, want := l.Token(), "Hello\n!"; got != want {
+		t.Errorf("Token: want: %q, got: %q", want, got)
+	}
+}
+
+func TestLexer_Find_no_match(t *testing.T) {
+	t.Parallel()
+
+	l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
+
+	token := l.Find([]string{"no match"})
+	if err := l.Err(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got, want := token, ""; got != want {
+		t.Errorf("unexpected token: want: %q, got: %q", want, got)
+	}
+
+	if got, want := l.Pos(), 12; got != want {
+		t.Errorf("Pos: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Cursor(), 0; got != want {
+		t.Errorf("Cursor: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Line(), 2; got != want {
+		t.Errorf("Line: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Column(), 7; got != want {
+		t.Errorf("Column: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Width(), 12; got != want {
+		t.Errorf("Width: want: %v, got: %v", want, got)
+	}
+
+	if got, want := l.Token(), "Hello\n!Find!"; got != want {
+		t.Errorf("Token: want: %q, got: %q", want, got)
+	}
 }
 
 func TestLexer_Ignore(t *testing.T) {
@@ -376,16 +623,16 @@ func TestLexer_Ignore(t *testing.T) {
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Ignore!\n")), nil, &lexWordState{})
 
-		advanced, err := l.Advance(7)
-		if err != nil {
+		advanced := l.AdvanceN(7)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := advanced, 7; got != want {
 			t.Errorf("Advance: want: %v, got: %v", want, got)
 		}
 
-		rns, err := l.Peek(7)
-		if err != nil {
+		rns := l.PeekN(7)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := string(rns), "Ignore!"; got != want {
@@ -418,16 +665,16 @@ func TestLexer_Ignore(t *testing.T) {
 
 		l.Ignore()
 
-		advanced, err = l.Advance(7)
-		if err != nil {
+		advanced = l.AdvanceN(7)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := advanced, 7; got != want {
 			t.Errorf("Advance: want: %v, got: %v", want, got)
 		}
 
-		rns, err = l.Peek(1)
-		if err != nil {
+		rns = l.PeekN(1)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := string(rns), "\n"; got != want {
@@ -460,7 +707,7 @@ func TestLexer_Ignore(t *testing.T) {
 	})
 }
 
-func TestLexer_SkipTo(t *testing.T) {
+func TestLexer_DiscardTo(t *testing.T) {
 	t.Parallel()
 
 	t.Run("match", func(t *testing.T) {
@@ -468,16 +715,16 @@ func TestLexer_SkipTo(t *testing.T) {
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
 
-		token, err := l.SkipTo([]string{"Find"})
-		if err != nil {
+		token := l.DiscardTo([]string{"Find"})
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := token, "Find"; got != want {
 			t.Errorf("unexpected token: want: %q, got: %q", want, got)
 		}
 
-		rns, err := l.Peek(5)
-		if err != nil {
+		rns := l.PeekN(5)
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := string(rns), "Find!"; got != want {
@@ -514,8 +761,8 @@ func TestLexer_SkipTo(t *testing.T) {
 
 		l := NewLexer(runeio.NewReader(strings.NewReader("Hello\n!Find!")), nil, &lexWordState{})
 
-		token, err := l.SkipTo([]string{"no match"})
-		if !errors.Is(err, io.EOF) {
+		token := l.DiscardTo([]string{"no match"})
+		if err := l.Err(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got, want := token, ""; got != want {
@@ -577,6 +824,7 @@ func TestLexer_tokens(t *testing.T) {
 			Line:   1,
 			Column: 7,
 		},
+		&tokenEOF,
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/lexparse.go
+++ b/lexparse.go
@@ -34,11 +34,13 @@ func LexParse[V comparable](
 	var parseErr error
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	wg.Add(1)
 	go func() {
 		lexErr = l.Lex(ctx)
+		if lexErr != nil {
+			cancel()
+		}
 		wg.Done()
 	}()
 

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -28,13 +28,16 @@ import (
 type parseWordState struct{}
 
 func (w *parseWordState) Run(_ context.Context, p *Parser[string]) error {
-	l := p.Next()
-	if l == nil {
+	switch token := p.Next(); token.Type {
+	case wordType:
+		p.Node(token.Value)
+		p.PushState(w)
 		return nil
+	case TokenTypeEOF:
+		return nil
+	default:
+		panic("unknown type")
 	}
-	p.Node(l.Value)
-	p.PushState(w)
-	return nil
 }
 
 var (

--- a/parser.go
+++ b/parser.go
@@ -17,7 +17,6 @@ package lexparse
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -136,7 +135,7 @@ func (p *Parser[V]) Parse(ctx context.Context) (*Node[V], error) {
 		select {
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
-				return p.Root(), fmt.Errorf("parsing: %w", err)
+				return p.Root(), err
 			}
 			return p.Root(), nil
 		default:
@@ -148,7 +147,7 @@ func (p *Parser[V]) Parse(ctx context.Context) (*Node[V], error) {
 				break
 			}
 
-			return p.Root(), fmt.Errorf("parsing: %w", err)
+			return p.Root(), err
 		}
 	}
 	return p.Root(), nil
@@ -174,7 +173,7 @@ func (p *Parser[V]) Peek() *Token {
 	}
 	l, ok := <-p.tokens
 	if !ok {
-		return nil
+		return &tokenEOF
 	}
 	p.next = l
 	return p.next

--- a/parser_test.go
+++ b/parser_test.go
@@ -64,8 +64,13 @@ func testParse(t *testing.T, input string) (*Node[string], error) {
 	p := NewParser[string](tokens, ParseStateFn(func(_ context.Context, p *Parser[string]) error {
 		for {
 			token := p.Next()
-			if token == nil {
-				break
+			switch token.Type {
+			case wordType:
+				// OK
+			case TokenTypeEOF:
+				return nil
+			default:
+				panic("unknown type")
 			}
 
 			switch token.Value {
@@ -80,7 +85,6 @@ func testParse(t *testing.T, input string) (*Node[string], error) {
 				p.Node(token.Value)
 			}
 		}
-		return nil
 	}))
 
 	root, err := p.Parse(context.Background())
@@ -207,7 +211,7 @@ func TestParser_NextPeek(t *testing.T) {
 
 	// expected end of tokens
 	niltoken := p.Next()
-	if diff := cmp.Diff((*Token)(nil), niltoken); diff != "" {
+	if diff := cmp.Diff(&tokenEOF, niltoken); diff != "" {
 		t.Fatalf("Next: (-want, +got): \n%s", diff)
 	}
 }


### PR DESCRIPTION
**Description:**

Updates the API to add an EOF rune and EOF token which denote the end of input. Most utility functions don't return an error now deferring error handling until later and making implementation of `LexState` and `ParseState` easier. 

**Related Issues:**

Fixes #95
Fixes #99 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
