### PR TITLE
feat: add lexer implementation based on text/scanner

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -25,9 +25,6 @@ import (
 // TokenType is a user-defined Token type.
 type TokenType int
 
-// TokenTypeEOF indicates an EOF token signaling the end of input.
-var TokenTypeEOF TokenType = -1
-
 type Position struct {
 	// Filename is the name of the file being read. It can be empty if the
 	// input is not from a file.

--- a/lexer/scanner.go
+++ b/lexer/scanner.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Ian Lewis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"text/scanner"
+)
+
+var errScanner = errors.New("scanner error")
+
+var (
+	// TokenTypeEOF represents the end of the file.
+	TokenTypeEOF = TokenType(scanner.EOF)
+
+	// TokenTypeIdent represents an identifier.
+	TokenTypeIdent = TokenType(scanner.Ident)
+
+	// TokenTypeInt represents an integer literal.
+	TokenTypeInt = TokenType(scanner.Int)
+
+	// TokenTypeFloat represents a floating-point literal.
+	TokenTypeFloat = TokenType(scanner.Float)
+
+	// TokenTypeChar represents a character literal.
+	TokenTypeChar = TokenType(scanner.Char)
+
+	// TokenTypeString represents a string literal.
+	TokenTypeString = TokenType(scanner.String)
+
+	// TokenTypeRawString represents a raw string literal.
+	TokenTypeRawString = TokenType(scanner.RawString)
+
+	// TokenTypeComment represents a comment.
+	TokenTypeComment = TokenType(scanner.Comment)
+)
+
+// ScanningLexer is a lexer that uses the text/scanner package to tokenize
+// input streams.
+type ScanningLexer struct {
+	s *scanner.Scanner
+
+	// err is the first error the lexer encountered.
+	err error
+}
+
+// NewScanningLexer creates a new ScanningLexer that reads from the given
+// [io.Reader].
+func NewScanningLexer(r io.Reader) *ScanningLexer {
+	l := ScanningLexer{}
+	l.s = &scanner.Scanner{
+		Error: func(s *scanner.Scanner, msg string) {
+			if l.err == nil {
+				l.err = fmt.Errorf("%w: %s: %s", errScanner, s.Position, msg)
+			}
+		},
+	}
+	l.s = l.s.Init(r)
+
+	return &l
+}
+
+// NextToken implements [Lexer.NextToken]. It returns the next token from
+// the input stream.
+func (l *ScanningLexer) NextToken(_ context.Context) *Token {
+	if l.err != nil {
+		return l.newToken(TokenTypeEOF)
+	}
+
+	tok := l.s.Scan()
+	switch tok {
+	case scanner.EOF:
+		return l.newToken(TokenTypeEOF)
+	default:
+		return l.newToken(TokenType(tok))
+	}
+}
+
+// Err implements [Lexer.Err]. It returns the first error encountered by
+// the lexer, if any.
+func (l *ScanningLexer) Err() error {
+	return l.err
+}
+
+func (l *ScanningLexer) newToken(typ TokenType) *Token {
+	return &Token{
+		Type:  typ,
+		Value: l.s.TokenText(),
+		Start: Position(l.s.Position),
+		End:   Position(l.s.Pos()),
+	}
+}

--- a/lexer/scanner_test.go
+++ b/lexer/scanner_test.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Ian Lewis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lexer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"text/scanner"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestScannerLexer_NextToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []*Token
+	}{
+		{
+			name:  "simple input",
+			input: "abc := 123 + 456",
+			expected: []*Token{
+				{
+					Type:  TokenType(scanner.Ident),
+					Value: "abc",
+					Start: Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+					End: Position{
+						Offset: 3,
+						Line:   1,
+						Column: 4,
+					},
+				},
+				{
+					Type:  TokenType(':'),
+					Value: ":",
+					Start: Position{
+						Offset: 4,
+						Line:   1,
+						Column: 5,
+					},
+					End: Position{
+						Offset: 5,
+						Line:   1,
+						Column: 6,
+					},
+				},
+				{
+					Type:  TokenType('='),
+					Value: "=",
+					Start: Position{
+						Offset: 5,
+						Line:   1,
+						Column: 6,
+					},
+					End: Position{
+						Offset: 6,
+						Line:   1,
+						Column: 7,
+					},
+				},
+				{
+					Type:  TokenType(scanner.Int),
+					Value: "123",
+					Start: Position{
+						Offset: 7,
+						Line:   1,
+						Column: 8,
+					},
+					End: Position{
+						Offset: 10,
+						Line:   1,
+						Column: 11,
+					},
+				},
+				{
+					Type:  TokenType('+'),
+					Value: "+",
+					Start: Position{
+						Offset: 11,
+						Line:   1,
+						Column: 12,
+					},
+					End: Position{
+						Offset: 12,
+						Line:   1,
+						Column: 13,
+					},
+				},
+				{
+					Type:  TokenType(scanner.Int),
+					Value: "456",
+					Start: Position{
+						Offset: 13,
+						Line:   1,
+						Column: 14,
+					},
+					End: Position{
+						Offset: 16,
+						Line:   1,
+						Column: 17,
+					},
+				},
+				{
+					Type:  TokenTypeEOF,
+					Value: "",
+					Start: Position{
+						Offset: 16,
+						Line:   1,
+						Column: 17,
+					},
+					End: Position{
+						Offset: 16,
+						Line:   1,
+						Column: 17,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lexer := NewScanningLexer(strings.NewReader(tt.input))
+			var tokens []*Token
+			for {
+				token := lexer.NextToken(context.Background())
+				tokens = append(tokens, token)
+				if token.Type == TokenTypeEOF {
+					break
+				}
+			}
+
+			if diff := cmp.Diff(tt.expected, tokens); diff != "" {
+				t.Errorf("Tokens mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

Add a `lexer.Lexer` implementation based on `text/scanner`.

**Related Issues:**

Fixes #132 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
