### PR TITLE
chore: re-enable linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,8 +63,7 @@ linters:
     - copyloopvar
 
     # Checks function and package cyclomatic complexity.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - cyclop
+    - cyclop
 
     # Check declaration order and count of types, constants, variables and
     # functions.
@@ -79,8 +78,7 @@ linters:
     - dogsled
 
     # Detects duplicate fragments of code.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - dupl
+    - dupl
 
     # Checks for duplicate words in the source code.
     - dupword
@@ -136,8 +134,7 @@ linters:
     - gocheckcompilerdirectives
 
     # Check that no global variables exist.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - gochecknoglobals
+    - gochecknoglobals
 
     # Checks that no init functions are present in Go code.
     - gochecknoinits
@@ -152,8 +149,7 @@ linters:
     - goconst
 
     # Provides diagnostics that check for bugs, performance and style issues.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - gocritic
+    - gocritic
 
     # Computes and checks the cyclomatic complexity of functions.
     # NOTE: gocyclo overlaps in functionality with cyclop.
@@ -184,7 +180,7 @@ linters:
     - gosec
 
     # Report certain i18n/l10n anti-patterns in your Go codebase.
-    # TODO(#142): Re-enable when its issues are fixed.
+    # NOTE: the project does not support i18n/l10n actively.
     # - gosmopolitan
 
     # Analyze expression groups.
@@ -198,20 +194,17 @@ linters:
     - importas
 
     # Reports interfaces with unnamed method parameters.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - inamedparam
+    - inamedparam
 
     # A linter that checks the number of methods inside an interface.
     - interfacebloat
 
     # Intrange is a linter to find places where for loops could make use of an
     # integer range.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - intrange
+    - intrange
 
     # Accept Interfaces, Return Concrete Types.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - ireturn
+    - ireturn
 
     # Reports long lines.
     - lll
@@ -255,8 +248,7 @@ linters:
     - nilnesserr
 
     # Checks that there is no simultaneous return of nil error and an invalid value.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - nilnil
+    - nilnil
 
     # nlreturn checks for a new line before return and branch statements to
     # increase code clarity.
@@ -302,8 +294,7 @@ linters:
 
     # Fast, configurable, extensible, flexible, and beautiful linter for Go.
     # Drop-in replacement of golint.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - revive
+    - revive
 
     # Checks whether Rows.Err of rows is checked successfully.
     - rowserrcheck
@@ -358,8 +349,7 @@ linters:
 
     # Checks that the length of a variable's name matches its scope.
     # NOTE: varnamelen isn't bad necessarily, but it is very noisy.
-    # TODO(#142): Re-enable when its issues are fixed.
-    # - varnamelen
+    - varnamelen
 
     # Finds wasted assignment statements.
     - wastedassign
@@ -385,7 +375,7 @@ linters:
   settings:
     cyclop:
       max-complexity: 30
-      package-average: 5
+      package-average: 6
 
     depguard:
       rules:
@@ -425,6 +415,11 @@ linters:
     errcheck:
       check-type-assertions: true
       check-blank: true
+
+    exhaustive:
+      # Presence of "default" case in switch statements satisfies
+      # exhaustiveness, even if all enum members are not listed.
+      default-signifies-exhaustive: true
 
     gocognit:
       min-complexity: 40

--- a/infix_example_test.go
+++ b/infix_example_test.go
@@ -91,13 +91,13 @@ func parseExpr(
 	default:
 	}
 
-	t := parser.Next(ctx)
+	token := parser.Next(ctx)
 	var lhs *lexparse.Node[*exprNode]
-	switch t.Type {
+	switch token.Type {
 	case lexer.TokenTypeFloat, lexer.TokenTypeInt:
-		num, err := strconv.ParseFloat(t.Value, 64)
+		num, err := strconv.ParseFloat(token.Value, 64)
 		if err != nil {
-			return nil, tokenErr(err, t)
+			return nil, tokenErr(err, token)
 		}
 		lhs = parser.NewNode(&exprNode{
 			typ: nodeTypeNum,
@@ -115,9 +115,9 @@ func parseExpr(
 			return nil, tokenErr(errUnclosedParen, t2)
 		}
 	case lexer.TokenTypeEOF:
-		return nil, tokenErr(io.ErrUnexpectedEOF, t)
+		return nil, tokenErr(io.ErrUnexpectedEOF, token)
 	default:
-		return nil, tokenErr(errUnexpectedIdentifier, t)
+		return nil, tokenErr(errUnexpectedIdentifier, token)
 	}
 
 outerL:

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -25,6 +25,7 @@ import (
 // TokenType is a user-defined Token type.
 type TokenType int
 
+// Position represents a position in an input.
 type Position struct {
 	// Filename is the name of the file being read. It can be empty if the
 	// input is not from a file.
@@ -79,7 +80,7 @@ type Lexer interface {
 	// NextToken returns the next token from the input. If there are no more
 	// tokens, the context is canceled, or an error occurs, it returns a Token
 	// with Type set to [TokenTypeEOF].
-	NextToken(context.Context) *Token
+	NextToken(ctx context.Context) *Token
 
 	// Err returns the error encountered by the lexer, if any. If the error
 	// encountered is [io.EOF], it will return nil.

--- a/lexer/scanner.go
+++ b/lexer/scanner.go
@@ -24,7 +24,7 @@ import (
 
 var errScanner = errors.New("scanner error")
 
-var (
+const (
 	// TokenTypeEOF represents the end of the file.
 	TokenTypeEOF = TokenType(scanner.EOF)
 


### PR DESCRIPTION
**Description:**

Re-enable linters:
- cyclop
- dupl
- gochecknoglobals
- gocritic
- inamedparam
- intrange
- ireturn
- nilnil
- revive
- varnamelen

**Related Issues:**

Updates #142 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
