### PR TITLE
chore: move merge lexer package back into lexparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ tokenize simple mathematical expressions.
 
 ```go
 r := strings.NewReader("1 + 3 * (4 - 2)")
-l := lexer.NewScanningLexer(r)
+l := lexparse.NewScanningLexer(r)
 
-t := &lexer.Token{}
+t := &lexparse.Token{}
 ctx := context.Background()
-for t.Type != lexer.TokenTypeEOF {
+for t.Type != lexparse.TokenTypeEOF {
     t = l.NextToken(ctx)
     fmt.Printf("%s\n", t)
 }
@@ -198,7 +198,7 @@ We will first need to define our token types.
 
 ```go
 const (
-    textType lexer.TokenType = iota
+    textType lexparse.TokenType = iota
     blockStartType
     blockEndType
     varStartType
@@ -217,7 +217,7 @@ advancing over the text.
 
 ```go
 // lexText tokenizes normal text.
-func lexText(_ context.Context, l *lexer.CustomLexer) (lexer.LexState, error) {
+func lexText(_ context.Context, l *lexparse.CustomLexer) (lexparse.LexState, error) {
     for {
         p := l.PeekN(2)
         switch string(p) {
@@ -225,7 +225,7 @@ func lexText(_ context.Context, l *lexer.CustomLexer) (lexer.LexState, error) {
             if l.Width() > 0 {
                 l.Emit(lexTypeText)
             }
-            return lexer.LexStateFn(lexCode), nil
+            return lexparse.LexStateFn(lexCode), nil
         default:
         }
 
@@ -252,11 +252,11 @@ to, and a reader for the input.
 
 ```go
 r := strings.NewReader(textString)
-l := lexer.NewCustomLexer(r, initState)
+l := lexparse.NewCustomLexer(r, initState)
 
-t := &lexer.Token{}
+t := &lexparse.Token{}
 ctx := context.Background()
-for t.Type != lexer.TokenTypeEOF {
+for t.Type != lexparse.TokenTypeEOF {
     t = l.NextToken(ctx)
     fmt.Printf("%s\n", t)
 }
@@ -418,17 +418,17 @@ The `Parser` is initialized with a channel to receive tokens from, and the
 initial parser state.
 
 ```go
-tokens := make(chan *lexer.Token, 1024)
+tokens := make(chan *lexparse.Token, 1024)
 parser := lexparse.NewParser(tokens, initState),
 
 go func() {
     // send some tokens to the channel.
-    tokens<-lexer.Token{
+    tokens<-lexparse.Token{
         Type: tokenTypeText,
         Value: "some",
     }
 
-    tokens<-lexer.Token{
+    tokens<-lexparse.Token{
         Type: tokenTypeText,
         Value: "token",
     }
@@ -453,7 +453,7 @@ r := runeio.NewReader(strings.NewReader(tmpl))
 
 tree, err := lexparse.LexParse(
     context.Background(),
-    lexer.NewCustomLexer(r, lexparse.LexStateFn(lexText)),
+    lexparse.NewCustomLexer(r, lexparse.LexStateFn(lexText)),
     lexparse.ParseStateFn(parseRoot), // Starting parser state
 )
 ```

--- a/custom.go
+++ b/custom.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lexer
+package lexparse
 
 import (
 	"bufio"

--- a/custom_test.go
+++ b/custom_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lexer
+package lexparse
 
 import (
 	"context"

--- a/infix_example_test.go
+++ b/infix_example_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/ianlewis/lexparse"
-	"github.com/ianlewis/lexparse/lexer"
 )
 
 var (
@@ -67,7 +66,7 @@ func (n *exprNode) precedence() int {
 	}
 }
 
-func tokenErr(err error, t *lexer.Token) error {
+func tokenErr(err error, t *lexparse.Token) error {
 	return fmt.Errorf("%w: %q, line %d, column %d", err,
 		t.Value, t.Start.Line, t.Start.Column)
 }
@@ -98,7 +97,7 @@ func parseExpr(
 	var lhs *lexparse.Node[*exprNode]
 
 	switch token.Type {
-	case lexer.TokenTypeFloat, lexer.TokenTypeInt:
+	case lexparse.TokenTypeFloat, lexparse.TokenTypeInt:
 		num, err := strconv.ParseFloat(token.Value, 64)
 		if err != nil {
 			return nil, tokenErr(err, token)
@@ -121,7 +120,7 @@ func parseExpr(
 		if t2.Type != ')' {
 			return nil, tokenErr(errUnclosedParen, t2)
 		}
-	case lexer.TokenTypeEOF:
+	case lexparse.TokenTypeEOF:
 		return nil, tokenErr(io.ErrUnexpectedEOF, token)
 	default:
 		return nil, tokenErr(errUnexpectedIdentifier, token)
@@ -138,7 +137,7 @@ outerL:
 				typ:  nodeTypeOper,
 				oper: opToken.Value,
 			}
-		case lexer.TokenTypeEOF:
+		case lexparse.TokenTypeEOF:
 			break outerL
 		case ')':
 			if depth == 0 {
@@ -218,7 +217,7 @@ func Example_infixCalculator() {
 
 	t, err := lexparse.LexParse(
 		context.Background(),
-		lexer.NewScanningLexer(r),
+		lexparse.NewScanningLexer(r),
 		lexparse.ParseStateFn(pratt),
 	)
 	if err != nil {

--- a/lexer.go
+++ b/lexer.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package lexer defines a Lexer interface and related types for tokenizing
-// input streams.
-package lexer
+package lexparse
 
 import (
 	"context"

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -22,20 +22,18 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
-	"github.com/ianlewis/lexparse/lexer"
 )
 
 type parseTokenState struct{}
 
 func (w *parseTokenState) Run(ctx context.Context, p *Parser[string]) error {
 	switch token := p.Next(ctx); token.Type {
-	case lexer.TokenTypeIdent:
+	case TokenTypeIdent:
 		p.Node(token.Value)
 		p.PushState(w)
 
 		return nil
-	case lexer.TokenTypeEOF:
+	case TokenTypeEOF:
 		return nil
 	default:
 		panic("unknown type")
@@ -53,7 +51,7 @@ func TestScannerLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		l := lexer.NewScanningLexer(r)
+		l := NewScanningLexer(r)
 
 		got, err := LexParse(ctx, l, &parseTokenState{})
 		if err != nil {
@@ -62,7 +60,7 @@ func TestScannerLexParse(t *testing.T) {
 
 		expectedRoot := addParent(
 			&Node[string]{
-				Start: lexer.Position{
+				Start: Position{
 					Offset: 0,
 					Line:   1,
 					Column: 1,
@@ -70,7 +68,7 @@ func TestScannerLexParse(t *testing.T) {
 				Children: []*Node[string]{
 					{
 						Value: "Hello",
-						Start: lexer.Position{
+						Start: Position{
 							Offset: 0,
 							Line:   1,
 							Column: 1,
@@ -78,7 +76,7 @@ func TestScannerLexParse(t *testing.T) {
 					},
 					{
 						Value: "World",
-						Start: lexer.Position{
+						Start: Position{
 							Offset: 6,
 							Line:   2,
 							Column: 1,
@@ -103,7 +101,7 @@ func (w *parseWordState) Run(ctx context.Context, p *Parser[string]) error {
 		p.PushState(w)
 
 		return nil
-	case lexer.TokenTypeEOF:
+	case TokenTypeEOF:
 		return nil
 	default:
 		panic("unknown type")
@@ -117,8 +115,8 @@ var (
 
 type lexErrState struct{}
 
-//nolint:ireturn // returning interface is required to satisfy lexer.LexState.
-func (e *lexErrState) Run(context.Context, *lexer.CustomLexer) (lexer.LexState, error) {
+//nolint:ireturn // returning interface is required to satisfy LexState.
+func (e *lexErrState) Run(context.Context, *CustomLexer) (LexState, error) {
 	return nil, errState
 }
 
@@ -140,7 +138,7 @@ func TestCustomLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		l := lexer.NewCustomLexer(r, &lexWordState{})
+		l := NewCustomLexer(r, &lexWordState{})
 
 		got, err := LexParse(ctx, l, &parseWordState{})
 		if err != nil {
@@ -149,7 +147,7 @@ func TestCustomLexParse(t *testing.T) {
 
 		expectedRoot := addParent(
 			&Node[string]{
-				Start: lexer.Position{
+				Start: Position{
 					Offset: 0,
 					Line:   1,
 					Column: 1,
@@ -157,7 +155,7 @@ func TestCustomLexParse(t *testing.T) {
 				Children: []*Node[string]{
 					{
 						Value: "Hello",
-						Start: lexer.Position{
+						Start: Position{
 							Offset: 0,
 							Line:   1,
 							Column: 1,
@@ -165,7 +163,7 @@ func TestCustomLexParse(t *testing.T) {
 					},
 					{
 						Value: "World!",
-						Start: lexer.Position{
+						Start: Position{
 							Offset: 6,
 							Line:   2,
 							Column: 1,
@@ -189,7 +187,7 @@ func TestCustomLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		l := lexer.NewCustomLexer(r, &lexErrState{})
+		l := NewCustomLexer(r, &lexErrState{})
 		_, got := LexParse(ctx, l, &parseErrState{})
 
 		want := errState
@@ -207,7 +205,7 @@ func TestCustomLexParse(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		l := lexer.NewCustomLexer(r, &lexWordState{})
+		l := NewCustomLexer(r, &lexWordState{})
 		_, got := LexParse(ctx, l, &parseErrState{})
 
 		want := errParse

--- a/parser.go
+++ b/parser.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"errors"
 	"io"
-
-	"github.com/ianlewis/lexparse/lexer"
 )
 
 // Node is the structure for a single node in the parse tree.
@@ -29,7 +27,7 @@ type Node[V comparable] struct {
 	Value    V
 
 	// Start is the start position in the input where the value was found.
-	Start lexer.Position
+	Start Position
 }
 
 // ParseState is the state of the current parsing state machine. It defines the logic
@@ -80,15 +78,15 @@ func (s *stack[V]) pop() ParseState[V] {
 // TokenSource is an interface that defines a source of tokens for the parser.
 type TokenSource interface {
 	// NextToken returns the next token from the source. When tokens are
-	// exhausted, it returns a Token with Type set to [lexer.TokenTypeEOF].
-	NextToken(ctx context.Context) *lexer.Token
+	// exhausted, it returns a Token with Type set to [TokenTypeEOF].
+	NextToken(ctx context.Context) *Token
 }
 
 // NewParser creates a new Parser that reads from the tokens channel. The
 // parser is initialized with a root node with an empty value.
 func NewParser[V comparable](tokens TokenSource, startingState ParseState[V]) *Parser[V] {
 	root := &Node[V]{
-		Start: lexer.Position{
+		Start: Position{
 			Offset: 0,
 			Line:   1,
 			Column: 1,
@@ -126,10 +124,10 @@ type Parser[V comparable] struct {
 	node *Node[V]
 
 	// token is the current token in the stream.
-	token *lexer.Token
+	token *Token
 
 	// next is the next token in the stream.
-	next *lexer.Token
+	next *Token
 }
 
 // Parse builds a parse tree by repeatedly pulling [ParseState] objects from
@@ -190,7 +188,7 @@ func (p *Parser[V]) Root() *Node[V] {
 }
 
 // Peek returns the next token from the lexer without consuming it.
-func (p *Parser[V]) Peek(ctx context.Context) *lexer.Token {
+func (p *Parser[V]) Peek(ctx context.Context) *Token {
 	if p.next != nil {
 		return p.next
 	}
@@ -202,7 +200,7 @@ func (p *Parser[V]) Peek(ctx context.Context) *lexer.Token {
 
 // Next returns the next token from the lexer. This is the new current token
 // position.
-func (p *Parser[V]) Next(ctx context.Context) *lexer.Token {
+func (p *Parser[V]) Next(ctx context.Context) *Token {
 	l := p.Peek(ctx)
 	p.next = nil
 	p.token = l
@@ -235,7 +233,7 @@ func (p *Parser[V]) Node(v V) *Node[V] {
 // NewNode creates a new node at the current token position and returns it
 // without adding it to the tree.
 func (p *Parser[V]) NewNode(v V) *Node[V] {
-	var start lexer.Position
+	var start Position
 	if p.token != nil {
 		start = p.token.Start
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lexer
+package lexparse
 
 import (
 	"context"

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lexer
+package lexparse
 
 import (
 	"context"


### PR DESCRIPTION
**Description:**

Merge the `lexer` package back into the `lexparse` main package since it's not necessary to separate them.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
