### PR TITLE
feat: add fmt.Stringer implementation for Node

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -17,6 +17,7 @@ package lexparse
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -30,8 +31,42 @@ type Node[V comparable] struct {
 	Start Position
 }
 
-// ParseState is the state of the current parsing state machine. It defines the logic
-// to process the current state and returns the next state.
+func (n *Node[V]) String() string {
+	return fmtNode(n, nil)
+}
+
+func fmtNode[V comparable](node *Node[V], lastRank []bool) string {
+	nodeStr := ""
+
+	for i := range len(lastRank) - 1 {
+		if lastRank[i] {
+			nodeStr += "    "
+		} else {
+			nodeStr += "│   "
+		}
+	}
+
+	if len(lastRank) > 0 {
+		if lastRank[len(lastRank)-1] {
+			nodeStr += "└── "
+		} else {
+			nodeStr += "├── "
+		}
+	}
+
+	nodeStr += fmt.Sprintf("%v (%v)\n", node.Value, node.Start)
+	for i, child := range node.Children {
+		newLastRank := make([]bool, len(lastRank)+1)
+		copy(newLastRank, lastRank)
+		newLastRank[len(lastRank)] = i == len(node.Children)-1
+		nodeStr += fmtNode(child, newLastRank)
+	}
+
+	return nodeStr
+}
+
+// ParseState is the state of the current parsing state machine. It defines the
+// logic to process the current state and returns the next state.
 type ParseState[V comparable] interface {
 	// Run executes the logic at the current state, returning an error if one is
 	// encountered. Implementations are expected to add new [Node] objects to

--- a/parser_test.go
+++ b/parser_test.go
@@ -524,3 +524,67 @@ func TestParser_Replace_root(t *testing.T) {
 		t.Errorf("p.root (-want, +got): \n%s", diff)
 	}
 }
+
+func TestNode_String(t *testing.T) {
+	t.Parallel()
+
+	node := &Node[string]{
+		Value: "root",
+		Start: Position{
+			Offset: 0,
+			Line:   1,
+			Column: 1,
+		},
+		Children: []*Node[string]{
+			{
+				Value: "child1",
+
+				Start: Position{
+					Offset: 1,
+					Line:   1,
+					Column: 2,
+				},
+				Children: []*Node[string]{
+					{
+						Value: "grandchild1",
+
+						Start: Position{
+							Offset: 2,
+							Line:   1,
+							Column: 3,
+						},
+					},
+				},
+			},
+			{
+				Value: "child2",
+				Start: Position{
+					Offset: 3,
+					Line:   1,
+					Column: 4,
+				},
+				Children: []*Node[string]{
+					{
+						Value: "grandchild2",
+						Start: Position{
+							Offset: 4,
+							Line:   1,
+							Column: 5,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := `root (1:1)
+├── child1 (1:2)
+│   └── grandchild1 (1:3)
+└── child2 (1:4)
+    └── grandchild2 (1:5)
+`
+
+	if diff := cmp.Diff(expected, node.String()); diff != "" {
+		t.Errorf("Node.String() (-want, +got): \n%s", diff)
+	}
+}


### PR DESCRIPTION
**Description:**

Add a `fmt.Stringer` implementation for `Node`. The `String` method prints the full tree structure of the `Node` and its children in a human friendly format similar to the GNU `tree` program.

**Related Issues:**

Fixes #98 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
