### PR TITLE
fix: do not return EOF from Err

### DIFF
--- a/custom.go
+++ b/custom.go
@@ -212,8 +212,6 @@ func (l *CustomLexer) NextToken(ctx context.Context) *Token {
 
 	// The state is nil and we have no tokens to return, so we are at the end
 	// of the input.
-	l.err = io.EOF
-
 	return l.newToken(TokenTypeEOF)
 }
 
@@ -455,6 +453,8 @@ func (l *CustomLexer) Emit(typ TokenType) *Token {
 	return token
 }
 
+// newToken creates a new token starting from the current cursor position to the
+// current reader position.
 func (l *CustomLexer) newToken(typ TokenType) *Token {
 	return &Token{
 		Type:  typ,

--- a/custom_test.go
+++ b/custom_test.go
@@ -948,7 +948,7 @@ func TestCustomLexer_NextToken(t *testing.T) {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(io.EOF, customLexer.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, customLexer.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})


### PR DESCRIPTION
**Description:**

Do not return `io.EOF` from `CustomLexer.Err`. `Err` should only return unexpected errors.

**Related Issues:**

Fixes #170 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
