### PR TITLE
feat: refactor API for CustomLexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Refactored `CustomLexer` to add a new `CustomLexerContext` type that is passed
+  to state functions. This context provides access to the underlying `Lexer`
+  as well as additional helper methods for lexing.
+
 ## [0.2.0] - 2025-10-31
 
 - The EOF token emitted by the `Lexer` now includes the position where the EOF

--- a/ini_example_test.go
+++ b/ini_example_test.go
@@ -87,12 +87,12 @@ var (
 // lexINI is the initial lexer state for INI files.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINI(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexState, error) {
+func lexINI(ctx *lexparse.CustomLexerContext) (lexparse.LexState, error) {
 	for {
-		rn := lexer.Peek()
+		rn := ctx.Peek()
 		switch rn {
 		case ' ', '\t', '\r', '\n':
-			lexer.Discard()
+			ctx.Discard()
 		case '[', ']', '=':
 			return lexparse.LexStateFn(lexINIOper), nil
 		case ';', '#':
@@ -108,9 +108,9 @@ func lexINI(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexState, 
 // lexINIOper lexes an operator token.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIOper(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexState, error) {
-	oper := lexer.NextRune()
-	lexer.Emit(lexINITypeOper)
+func lexINIOper(ctx *lexparse.CustomLexerContext) (lexparse.LexState, error) {
+	oper := ctx.NextRune()
+	ctx.Emit(lexINITypeOper)
 
 	if oper == '=' {
 		return lexparse.LexStateFn(lexINIValue), nil
@@ -122,9 +122,9 @@ func lexINIOper(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexSta
 // lexINIIden lexes an identifier token (section name or property key).
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIIden(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexState, error) {
-	if next := lexer.Find([]string{"]", "="}); next != "" {
-		lexer.Emit(lexINITypeIden)
+func lexINIIden(ctx *lexparse.CustomLexerContext) (lexparse.LexState, error) {
+	if next := ctx.Find([]string{"]", "="}); next != "" {
+		ctx.Emit(lexINITypeIden)
 		return lexparse.LexStateFn(lexINIOper), nil
 	}
 
@@ -134,9 +134,9 @@ func lexINIIden(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexSta
 // lexINIValue lexes a property value token.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIValue(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexState, error) {
-	lexer.Find([]string{";", "\n"})
-	lexer.Emit(lexINITypeValue)
+func lexINIValue(ctx *lexparse.CustomLexerContext) (lexparse.LexState, error) {
+	ctx.Find([]string{";", "\n"})
+	ctx.Emit(lexINITypeValue)
 
 	return lexparse.LexStateFn(lexINI), nil
 }
@@ -144,9 +144,9 @@ func lexINIValue(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexSt
 // lexINIComment lexes a comment token.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIComment(_ context.Context, lexer *lexparse.CustomLexer) (lexparse.LexState, error) {
-	lexer.Find([]string{"\n"})
-	lexer.Emit(lexINITypeComment)
+func lexINIComment(ctx *lexparse.CustomLexerContext) (lexparse.LexState, error) {
+	ctx.Find([]string{"\n"})
+	ctx.Emit(lexINITypeComment)
 
 	return lexparse.LexStateFn(lexINI), nil
 }

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -48,8 +48,7 @@ func TestScannerLexParse(t *testing.T) {
 
 		r := strings.NewReader("Hello\nWorld")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		l := NewScanningLexer(r)
 
@@ -116,7 +115,7 @@ var (
 type lexErrState struct{}
 
 //nolint:ireturn // returning interface is required to satisfy LexState.
-func (e *lexErrState) Run(context.Context, *CustomLexer) (LexState, error) {
+func (e *lexErrState) Run(*CustomLexerContext) (LexState, error) {
 	return nil, errState
 }
 
@@ -135,8 +134,7 @@ func TestCustomLexParse(t *testing.T) {
 
 		r := strings.NewReader("Hello\nWorld!")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		l := NewCustomLexer(r, &lexWordState{})
 
@@ -184,8 +182,7 @@ func TestCustomLexParse(t *testing.T) {
 
 		r := strings.NewReader("Hello\nWorld!")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		l := NewCustomLexer(r, &lexErrState{})
 		_, got := LexParse(ctx, l, &parseErrState{})
@@ -202,8 +199,7 @@ func TestCustomLexParse(t *testing.T) {
 
 		r := strings.NewReader("Hello\nWorld!")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		l := NewCustomLexer(r, &lexWordState{})
 		_, got := LexParse(ctx, l, &parseErrState{})


### PR DESCRIPTION
**Description:**

Refactor the API for `CustomLexer` to add a `CustomLexerContext`. The context wraps the `context.Context` during lexing, and provides methods for accessing the input stream.

**Related Issues:**

Updates #173 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
