### PR TITLE
feat: refactor the Parser API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `CustomLexer` to add a new `CustomLexerContext` type that is passed
   to state functions. This context provides access to the underlying `Lexer`
   as well as additional helper methods for lexing.
+- Refactored `Parser` to add a new `ParserContext` type that is passed
+  to state functions. This context provides access to the underlying `Parser`
+  as well as additional helper methods for parsing.
 
 ## [0.2.0] - 2025-10-31
 

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -15,7 +15,6 @@
 package lexparse
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -26,11 +25,11 @@ import (
 
 type parseTokenState struct{}
 
-func (w *parseTokenState) Run(ctx context.Context, p *Parser[string]) error {
-	switch token := p.Next(ctx); token.Type {
+func (w *parseTokenState) Run(ctx *ParserContext[string]) error {
+	switch token := ctx.Next(); token.Type {
 	case TokenTypeIdent:
-		p.Node(token.Value)
-		p.PushState(w)
+		ctx.Node(token.Value)
+		ctx.PushState(w)
 
 		return nil
 	case TokenTypeEOF:
@@ -93,11 +92,11 @@ func TestScannerLexParse(t *testing.T) {
 
 type parseWordState struct{}
 
-func (w *parseWordState) Run(ctx context.Context, p *Parser[string]) error {
-	switch token := p.Next(ctx); token.Type {
+func (w *parseWordState) Run(ctx *ParserContext[string]) error {
+	switch token := ctx.Next(); token.Type {
 	case wordType:
-		p.Node(token.Value)
-		p.PushState(w)
+		ctx.Node(token.Value)
+		ctx.PushState(w)
 
 		return nil
 	case TokenTypeEOF:
@@ -121,8 +120,8 @@ func (e *lexErrState) Run(*CustomLexerContext) (LexState, error) {
 
 type parseErrState struct{}
 
-func (e *parseErrState) Run(ctx context.Context, p *Parser[string]) error {
-	_ = p.Next(ctx)
+func (e *parseErrState) Run(ctx *ParserContext[string]) error {
+	_ = ctx.Next()
 	return errParse
 }
 


### PR DESCRIPTION
**Description:**

Refactor `Parser` to add a new `ParserContext`. This type specifies the methods that parser state functions use to interact with the parser.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
