### PR TITLE
fix: remove stderr print from example test

### DIFF
--- a/template_example_test.go
+++ b/template_example_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -432,7 +431,6 @@ func parseBlockStart(ctx *lexparse.ParserContext[*tmplNode]) error {
 	switch token := ctx.Next(); token.Type {
 	case lexTypeBlockStart:
 		// OK
-		fmt.Fprintln(os.Stderr, token.Value)
 	case lexparse.TokenTypeEOF:
 		return fmt.Errorf("%w: expected %q", io.ErrUnexpectedEOF, tokenBlockStart)
 	default:
@@ -456,7 +454,7 @@ func parseBlockStart(ctx *lexparse.ParserContext[*tmplNode]) error {
 	case tokenIf:
 		ctx.PushState(lexparse.ParseStateFn(parseBranch))
 	case tokenElse, tokenEndif:
-		// NOTE: parseElse,parseEndif should already be on the stack.
+		// NOTE: parseElse, parseEndif should already be on the stack.
 	default:
 		return lexTokenErr(
 			fmt.Errorf("%w: expected %q, %q, or %q", errIdentifier, tokenIf, tokenElse, tokenEndif), token)


### PR DESCRIPTION
**Description:**

Remove a print to stderr debug statement from the template example test.

**Related Issues:**

Fixes #181

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
