### PR TITLE
feat: update ParseCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Renamed `CustomLexerContext` to `CustomLexerCursor` and separated it from the
+- Renamed `CustomLexerContext` to `LexCursor` and separated it from the
+  `context.Context` type.
+- Renamed `ParserContext` to `ParseCursor` and separated it from the
   `context.Context` type.
 
 ## [0.3.0] - 2026-01-25

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ in addition to the underlying reader's position. When the token has been fully
 processed it can be emitted to a channel for further processing by the `Parser`.
 
 Developers implement the token processing portion of the lexer by implementing
-`LexState` interface for each relevant lexer state. A `CustomLexerCursor` is
-passed to each `LexState` during processing and includes a number of methods
-that can be used to advance through the input text.
+`LexState` interface for each relevant lexer state. A `LexCursor` is passed to
+each `LexState` during processing and includes a number of methods that can be
+used to advance through the input text.
 
 For example, consider the following simple template language.
 
@@ -211,7 +211,7 @@ type LexState interface {
     // Run returns the next state to transition to or an error. If the returned
     // next state is nil or the returned error is io.EOF then the Lexer
     // finishes processing normally.
-    Run(context.Context, *CustomLexerCursor) (LexState, error)
+    Run(context.Context, *LexCursor) (LexState, error)
 }
 ```
 
@@ -238,23 +238,23 @@ advancing over the text.
 
 ```go
 // lexText tokenizes normal text.
-func lexText(ctx context.Context, c *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
+func lexText(ctx context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
     for {
-        p := c.PeekN(2)
+        p := cur.PeekN(2)
         switch string(p) {
         case tokenBlockStart, tokenVarStart:
-            if c.Width() > 0 {
-                c.Emit(lexTypeText)
+            if cur.Width() > 0 {
+                cur.Emit(lexTypeText)
             }
             return lexparse.LexStateFn(lexCode), nil
         default:
         }
 
         // Advance the input.
-        if !c.Advance() {
+        if !cur.Advance() {
             // End of input. Emit the text up to this point.
-            if c.Width() > 0 {
-                c.Emit(lexTypeText)
+            if cur.Width() > 0 {
+                cur.Emit(lexTypeText)
             }
             return nil, nil
         }
@@ -326,7 +326,7 @@ flowchart-elk TD
 
 Similar to the lexer API, each parser state is represented by an object
 implementing the `ParseState` interface. It contains only a single `Run` method
-which handles processing input tokens while in that state. A `ParserContext` is
+which handles processing input tokens while in that state. A `ParseCursor` is
 passed to each `ParseState` during processing and includes a number of methods
 that can be used to examine the current token, advance to the next token, and
 manipulate the AST.
@@ -335,10 +335,11 @@ manipulate the AST.
 // ParseState is the state of the current parsing state machine. It defines the
 // logic to process the current state and returns the next state.
 type ParseState[V comparable] interface {
-    // Run returns the next state to transition to or an error. If the returned
-    // next state is nil or the returned error is io.EOF then the Lexer
-    // finishes processing normally.
-    Run(*ParserContext[V]) (ParseState[V], error)
+    // Run executes the logic at the current state, returning an error if one is
+    // encountered. Implementations are expected to add new [Node] objects to
+    // the AST using [Parser.Push] or [Parser.Node). As necessary, new parser
+    // state should be pushed onto the stack as needed using [Parser.PushState].
+    Run(ctx context.Context, cur *ParseCursor[V]) error
 }
 ```
 
@@ -377,16 +378,16 @@ Here we push the later relevant expected state onto the parser's stack.
 
 ```go
 // parseSeq delegates to another parse function based on token type.
-func parseSeq(ctx *lexparse.ParserContext[*tmplNode]) error {
-    token := ctx.Peek()
+func parseSeq(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+    token := cur.Peek(ctx)
 
     switch token.Type {
     case lexTypeText:
-        ctx.PushState(lexparse.ParseStateFn(parseText))
+        cur.PushState(lexparse.ParseStateFn(parseText))
     case lexTypeVarStart:
-        ctx.PushState(lexparse.ParseStateFn(parseVarStart))
+        cur.PushState(lexparse.ParseStateFn(parseVarStart))
     case lexTypeBlockStart:
-        ctx.PushState(lexparse.ParseStateFn(parseBlockStart))
+        cur.PushState(lexparse.ParseStateFn(parseBlockStart))
     }
 
     return nil
@@ -399,11 +400,11 @@ are pushed in reverse order so that they are handled in the order listed.
 
 ```go
 // parseVarStart handles var start (e.g. '{{').
-func parseVarStart(ctx *lexparse.ParserContext[*tmplNode]) error {
+func parseVarStart(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
     // Consume the var start token.
-    _ = ctx.Next()
+    _ = cur.Next(ctx)
 
-    ctx.PushState(
+    cur.PushState(
         lexparse.ParseStateFn(parseVar),
         lexparse.ParseStateFn(parseVarEnd),
     )

--- a/README.md
+++ b/README.md
@@ -336,9 +336,10 @@ manipulate the AST.
 // logic to process the current state and returns the next state.
 type ParseState[V comparable] interface {
     // Run executes the logic at the current state, returning an error if one is
-    // encountered. Implementations are expected to add new [Node] objects to
-    // the AST using [Parser.Push] or [Parser.Node). As necessary, new parser
-    // state should be pushed onto the stack as needed using [Parser.PushState].
+    // encountered. Implementations are expected to add new Node objects to
+    // the AST using ParseCursor.Push or ParseCursor.Node. As necessary, new
+    // parser state should be pushed onto the stack as needed using
+    // Parser.PushState.
     Run(ctx context.Context, cur *ParseCursor[V]) error
 }
 ```

--- a/custom.go
+++ b/custom.go
@@ -35,70 +35,70 @@ const EOF rune = -1
 type LexState interface {
 	// Run returns the next state to transition to or an error. If the returned
 	// error is io.EOF then the Lexer finishes processing normally.
-	Run(ctx context.Context, cursor *CustomLexerCursor) (LexState, error)
+	Run(ctx context.Context, cur *LexCursor) (LexState, error)
 }
 
 type lexFnState struct {
-	f func(context.Context, *CustomLexerCursor) (LexState, error)
+	f func(context.Context, *LexCursor) (LexState, error)
 }
 
 // Run implements [LexState.Run].
 //
 //nolint:ireturn // Returning interface required to satisfy [LexState.Run]
-func (s *lexFnState) Run(ctx context.Context, cursor *CustomLexerCursor) (LexState, error) {
-	return s.f(ctx, cursor)
+func (s *lexFnState) Run(ctx context.Context, cur *LexCursor) (LexState, error) {
+	return s.f(ctx, cur)
 }
 
 // LexStateFn creates a State from the given Run function.
 //
 //nolint:ireturn // Returning interface required to satisfy [LexState.Run]
-func LexStateFn(f func(context.Context, *CustomLexerCursor) (LexState, error)) LexState {
+func LexStateFn(f func(context.Context, *LexCursor) (LexState, error)) LexState {
 	return &lexFnState{f}
 }
 
-// CustomLexerCursor is a type that allows for processing the input for the
+// LexCursor is a type that allows for processing the input for the
 // CustomLexer. It provides methods to advance the reader, emit tokens, and
 // manage the current token being processed. It is designed to be used within
 // the [LexState.Run] method to allow the state implementation to interact with
 // the lexer without exposing the full CustomLexer implementation.
-type CustomLexerCursor struct {
+type LexCursor struct {
 	l *CustomLexer
 }
 
-// NewCustomLexerCursor creates a new CustomLexerCursor.
-func NewCustomLexerCursor(l *CustomLexer) *CustomLexerCursor {
-	return &CustomLexerCursor{
+// NewLexCursor creates a new CustomLexerCursor.
+func NewLexCursor(l *CustomLexer) *LexCursor {
+	return &LexCursor{
 		l: l,
 	}
 }
 
 // Advance attempts to advance the underlying reader a single rune and returns
 // true if actually advanced. The current token cursor position is not updated.
-func (c *CustomLexerCursor) Advance() bool {
+func (c *LexCursor) Advance() bool {
 	return c.l.advance(1, false) == 1
 }
 
 // AdvanceN attempts to advance the underlying reader n runes and returns the
 // number actually advanced. The current token cursor position is not updated.
-func (c *CustomLexerCursor) AdvanceN(n int) int {
+func (c *LexCursor) AdvanceN(n int) int {
 	return c.l.advance(n, false)
 }
 
 // Cursor returns the current position of the underlying cursor marking the
 // beginning of the current token being processed.
-func (c *CustomLexerCursor) Cursor() Position {
+func (c *LexCursor) Cursor() Position {
 	return c.l.cursor
 }
 
 // Discard attempts to discard the next rune, advancing the current token
 // cursor, and returns true if actually discarded.
-func (c *CustomLexerCursor) Discard() bool {
+func (c *LexCursor) Discard() bool {
 	return c.l.advance(1, true) == 1
 }
 
 // DiscardN attempts to discard n runes, advancing the current token cursor
 // position, and returns the number actually discarded.
-func (c *CustomLexerCursor) DiscardN(n int) int {
+func (c *LexCursor) DiscardN(n int) int {
 	return c.l.advance(n, true)
 }
 
@@ -106,14 +106,14 @@ func (c *CustomLexerCursor) DiscardN(n int) int {
 // the reader, and stopping when one of the strings is found. The token cursor
 // is advanced and data prior to the search string is discarded. The string
 // found is returned. If no match is found an empty string is returned.
-func (c *CustomLexerCursor) DiscardTo(query []string) string {
+func (c *LexCursor) DiscardTo(query []string) string {
 	return c.l.discardTo(query)
 }
 
 // Emit emits the token between the current cursor position and reader
 // position and returns the token. If the lexer is not currently active, this
 // is a no-op. This advances the current token cursor.
-func (c *CustomLexerCursor) Emit(typ TokenType) *Token {
+func (c *LexCursor) Emit(typ TokenType) *Token {
 	return c.l.emit(typ)
 }
 
@@ -121,25 +121,25 @@ func (c *CustomLexerCursor) Emit(typ TokenType) *Token {
 // reader, and stopping when one of the strings is found. The token cursor is
 // not advanced. The string found is returned. If no match is found an empty
 // string is returned.
-func (c *CustomLexerCursor) Find(query []string) string {
+func (c *LexCursor) Find(query []string) string {
 	return c.l.find(query)
 }
 
 // Ignore ignores the previous input and resets the token start position to
 // the current reader position.
-func (c *CustomLexerCursor) Ignore() {
+func (c *LexCursor) Ignore() {
 	c.l.ignore()
 }
 
 // NextRune returns the next rune of input, advancing the reader while not
 // advancing the token cursor.
-func (c *CustomLexerCursor) NextRune() rune {
+func (c *LexCursor) NextRune() rune {
 	return c.l.nextRune()
 }
 
 // Peek returns the next rune from the buffer without advancing the reader or
 // current token cursor.
-func (c *CustomLexerCursor) Peek() rune {
+func (c *LexCursor) Peek() rune {
 	p := c.PeekN(1)
 	if len(p) < 1 {
 		return EOF
@@ -151,23 +151,23 @@ func (c *CustomLexerCursor) Peek() rune {
 // PeekN returns the next n runes from the buffer without advancing the reader
 // or current token cursor. PeekN may return fewer runes than requested if an
 // error occurs or at end of input.
-func (c *CustomLexerCursor) PeekN(n int) []rune {
+func (c *LexCursor) PeekN(n int) []rune {
 	return c.l.peekN(n)
 }
 
 // Pos returns the current position of the underlying reader.
-func (c *CustomLexerCursor) Pos() Position {
+func (c *LexCursor) Pos() Position {
 	return c.l.pos
 }
 
 // Token returns the current token value.
-func (c *CustomLexerCursor) Token() string {
+func (c *LexCursor) Token() string {
 	return c.l.b.String()
 }
 
 // Width returns the current width of the token being processed. It is
 // equivalent to l.Pos().Offset - l.Cursor().Offset.
-func (c *CustomLexerCursor) Width() int {
+func (c *LexCursor) Width() int {
 	return c.l.pos.Offset - c.l.cursor.Offset
 }
 
@@ -246,7 +246,7 @@ func (l *CustomLexer) NextToken(ctx context.Context) *Token {
 		return l.newToken(TokenTypeEOF)
 	}
 
-	cursor := NewCustomLexerCursor(l)
+	cur := NewLexCursor(l)
 
 	// If we have no tokens to return, we need to run the current state.
 	for len(l.buf) == 0 && l.state != nil {
@@ -261,7 +261,7 @@ func (l *CustomLexer) NextToken(ctx context.Context) *Token {
 
 		var err error
 
-		l.state, err = l.state.Run(ctx, cursor)
+		l.state, err = l.state.Run(ctx, cur)
 		l.setErr(err)
 
 		if l.err != nil {

--- a/custom.go
+++ b/custom.go
@@ -56,8 +56,8 @@ func LexStateFn(f func(context.Context, *LexCursor) (LexState, error)) LexState 
 	return &lexFnState{f}
 }
 
-// LexCursor is a type that allows for processing the input for the
-// CustomLexer. It provides methods to advance the reader, emit tokens, and
+// LexCursor is a type that allows for processing the input for a
+// [CustomLexer]. It provides methods to advance the reader, emit tokens, and
 // manage the current token being processed. It is designed to be used within
 // the [LexState.Run] method to allow the state implementation to interact with
 // the lexer without exposing the full CustomLexer implementation.
@@ -65,7 +65,7 @@ type LexCursor struct {
 	l *CustomLexer
 }
 
-// NewLexCursor creates a new CustomLexerCursor.
+// NewLexCursor creates a new [LexCursor].
 func NewLexCursor(l *CustomLexer) *LexCursor {
 	return &LexCursor{
 		l: l,

--- a/custom_test.go
+++ b/custom_test.go
@@ -33,7 +33,7 @@ const (
 type lexWordState struct{}
 
 //nolint:ireturn // Returning interface required to satisfy [LexState.Run]
-func (w *lexWordState) Run(_ context.Context, c *CustomLexerCursor) (LexState, error) {
+func (w *lexWordState) Run(_ context.Context, c *LexCursor) (LexState, error) {
 	rn := c.Peek()
 	if unicode.IsSpace(rn) || rn == EOF {
 		// NOTE: This can emit empty words.
@@ -52,11 +52,11 @@ func (w *lexWordState) Run(_ context.Context, c *CustomLexerCursor) (LexState, e
 func TestCustomLexerCursor_Peek(t *testing.T) {
 	t.Parallel()
 
-	cursor := NewCustomLexerCursor(
+	cur := NewLexCursor(
 		NewCustomLexer(strings.NewReader("Hello\nWorld!"), &lexWordState{}),
 	)
 
-	rn := cursor.Peek()
+	rn := cur.Peek()
 
 	if diff := cmp.Diff('H', rn); diff != "" {
 		t.Errorf("Peek (-want +got):\n%s", diff)
@@ -68,7 +68,7 @@ func TestCustomLexerCursor_Peek(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+	if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 		t.Errorf("Pos (-want +got):\n%s", diff)
 	}
 
@@ -78,11 +78,11 @@ func TestCustomLexerCursor_Peek(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+	if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 		t.Errorf("Cursor (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Err (-want +got):\n%s", diff)
 	}
 }
@@ -90,15 +90,15 @@ func TestCustomLexerCursor_Peek(t *testing.T) {
 func TestCustomLexerCursor_PeekN(t *testing.T) {
 	t.Parallel()
 
-	cursor := NewCustomLexerCursor(
+	cur := NewLexCursor(
 		NewCustomLexer(strings.NewReader("Hello\nWorld!"), &lexWordState{}),
 	)
 
-	if diff := cmp.Diff("Hello\n", string(cursor.PeekN(6))); diff != "" {
+	if diff := cmp.Diff("Hello\n", string(cur.PeekN(6))); diff != "" {
 		t.Errorf("PeekN (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff("Hello\nWorld!", string(cursor.PeekN(16))); diff != "" {
+	if diff := cmp.Diff("Hello\nWorld!", string(cur.PeekN(16))); diff != "" {
 		t.Errorf("PeekN (-want +got):\n%s", diff)
 	}
 
@@ -108,7 +108,7 @@ func TestCustomLexerCursor_PeekN(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+	if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 		t.Errorf("Pos (-want +got):\n%s", diff)
 	}
 
@@ -118,11 +118,11 @@ func TestCustomLexerCursor_PeekN(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+	if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 		t.Errorf("Cursor (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Err (-want +got):\n%s", diff)
 	}
 }
@@ -134,15 +134,15 @@ func TestCustomLexerCursor_Advance(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Advance!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(true, cursor.Advance()); diff != "" {
+		if diff := cmp.Diff(true, cur.Advance()); diff != "" {
 			t.Errorf("Advance (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("ello\n!Adva", string(cursor.PeekN(10))); diff != "" {
+		if diff := cmp.Diff("ello\n!Adva", string(cur.PeekN(10))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -152,7 +152,7 @@ func TestCustomLexerCursor_Advance(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -162,19 +162,19 @@ func TestCustomLexerCursor_Advance(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(1, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(1, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("H", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("H", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -182,11 +182,11 @@ func TestCustomLexerCursor_Advance(t *testing.T) {
 	t.Run("end of input", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader(""), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(false, cursor.Advance()); diff != "" {
+		if diff := cmp.Diff(false, cur.Advance()); diff != "" {
 			t.Errorf("Advance (-want +got):\n%s", diff)
 		}
 
@@ -196,7 +196,7 @@ func TestCustomLexerCursor_Advance(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -206,19 +206,19 @@ func TestCustomLexerCursor_Advance(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -230,15 +230,15 @@ func TestCustomLexerCursor_AdvanceN(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Advance!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(5, cursor.AdvanceN(5)); diff != "" {
+		if diff := cmp.Diff(5, cur.AdvanceN(5)); diff != "" {
 			t.Errorf("AdvanceN (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("\n!Advance!", string(cursor.PeekN(10))); diff != "" {
+		if diff := cmp.Diff("\n!Advance!", string(cur.PeekN(10))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -248,7 +248,7 @@ func TestCustomLexerCursor_AdvanceN(t *testing.T) {
 			Column: 6,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -258,19 +258,19 @@ func TestCustomLexerCursor_AdvanceN(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(5, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(5, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Hello", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("Hello", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -278,11 +278,11 @@ func TestCustomLexerCursor_AdvanceN(t *testing.T) {
 	t.Run("past end", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Advance!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(15, cursor.AdvanceN(16)); diff != "" {
+		if diff := cmp.Diff(15, cur.AdvanceN(16)); diff != "" {
 			t.Errorf("AdvanceN (-want +got):\n%s", diff)
 		}
 
@@ -292,7 +292,7 @@ func TestCustomLexerCursor_AdvanceN(t *testing.T) {
 			Column: 10,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -302,19 +302,19 @@ func TestCustomLexerCursor_AdvanceN(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(15, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(15, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Hello\n!Advance!", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("Hello\n!Advance!", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -327,15 +327,15 @@ func TestCustomLexerCursor_Discard(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Advance!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(true, cursor.Discard()); diff != "" {
+		if diff := cmp.Diff(true, cur.Discard()); diff != "" {
 			t.Errorf("Discard (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("ello\n!Adva", string(cursor.PeekN(10))); diff != "" {
+		if diff := cmp.Diff("ello\n!Adva", string(cur.PeekN(10))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -345,7 +345,7 @@ func TestCustomLexerCursor_Discard(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -355,19 +355,19 @@ func TestCustomLexerCursor_Discard(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -375,11 +375,11 @@ func TestCustomLexerCursor_Discard(t *testing.T) {
 	t.Run("end of input", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader(""), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(false, cursor.Discard()); diff != "" {
+		if diff := cmp.Diff(false, cur.Discard()); diff != "" {
 			t.Errorf("Discard (-want +got):\n%s", diff)
 		}
 
@@ -389,7 +389,7 @@ func TestCustomLexerCursor_Discard(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -399,19 +399,19 @@ func TestCustomLexerCursor_Discard(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -423,15 +423,15 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Discard!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(7, cursor.DiscardN(7)); diff != "" {
+		if diff := cmp.Diff(7, cur.DiscardN(7)); diff != "" {
 			t.Errorf("DiscardN (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Discard!", string(cursor.PeekN(8))); diff != "" {
+		if diff := cmp.Diff("Discard!", string(cur.PeekN(8))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -441,7 +441,7 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -451,19 +451,19 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -471,11 +471,11 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 	t.Run("past end", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Discard!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(15, cursor.DiscardN(16)); diff != "" {
+		if diff := cmp.Diff(15, cur.DiscardN(16)); diff != "" {
 			t.Errorf("DiscardN (-want +got):\n%s", diff)
 		}
 
@@ -485,7 +485,7 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 			Column: 10,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -495,19 +495,19 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 			Column: 10,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -517,15 +517,15 @@ func TestCustomLexerCursor_DiscardN(t *testing.T) {
 func TestCustomLexerCursor_Find_match(t *testing.T) {
 	t.Parallel()
 
-	cursor := NewCustomLexerCursor(
+	cur := NewLexCursor(
 		NewCustomLexer(strings.NewReader("Hello\n!Find!"), &lexWordState{}),
 	)
 
-	if diff := cmp.Diff("Find", cursor.Find([]string{"Find"})); diff != "" {
+	if diff := cmp.Diff("Find", cur.Find([]string{"Find"})); diff != "" {
 		t.Errorf("Find (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff("Find!", string(cursor.PeekN(5))); diff != "" {
+	if diff := cmp.Diff("Find!", string(cur.PeekN(5))); diff != "" {
 		t.Errorf("PeekN (-want +got):\n%s", diff)
 	}
 
@@ -535,7 +535,7 @@ func TestCustomLexerCursor_Find_match(t *testing.T) {
 		Column: 2,
 	}
 
-	if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+	if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 		t.Errorf("Pos (-want +got):\n%s", diff)
 	}
 
@@ -545,19 +545,19 @@ func TestCustomLexerCursor_Find_match(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+	if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 		t.Errorf("Cursor (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(7, cursor.Width()); diff != "" {
+	if diff := cmp.Diff(7, cur.Width()); diff != "" {
 		t.Errorf("Width (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff("Hello\n!", cursor.Token()); diff != "" {
+	if diff := cmp.Diff("Hello\n!", cur.Token()); diff != "" {
 		t.Errorf("Token (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Err (-want +got):\n%s", diff)
 	}
 }
@@ -565,11 +565,11 @@ func TestCustomLexerCursor_Find_match(t *testing.T) {
 func TestCustomLexerCursor_Find_short_match(t *testing.T) {
 	t.Parallel()
 
-	cursor := NewCustomLexerCursor(
+	cur := NewLexCursor(
 		NewCustomLexer(strings.NewReader("Hello\n!Find!"), &lexWordState{}),
 	)
 
-	if diff := cmp.Diff("Find!", cursor.Find([]string{"no match", "Find!"})); diff != "" {
+	if diff := cmp.Diff("Find!", cur.Find([]string{"no match", "Find!"})); diff != "" {
 		t.Errorf("Find (-want +got):\n%s", diff)
 	}
 
@@ -579,7 +579,7 @@ func TestCustomLexerCursor_Find_short_match(t *testing.T) {
 		Column: 2,
 	}
 
-	if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+	if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 		t.Errorf("Pos (-want +got):\n%s", diff)
 	}
 
@@ -589,19 +589,19 @@ func TestCustomLexerCursor_Find_short_match(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+	if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 		t.Errorf("Cursor (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(7, cursor.Width()); diff != "" {
+	if diff := cmp.Diff(7, cur.Width()); diff != "" {
 		t.Errorf("Width (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff("Hello\n!", cursor.Token()); diff != "" {
+	if diff := cmp.Diff("Hello\n!", cur.Token()); diff != "" {
 		t.Errorf("Token (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Err (-want +got):\n%s", diff)
 	}
 }
@@ -610,11 +610,11 @@ func TestCustomLexerCursor_Find_short_match(t *testing.T) {
 func TestCustomLexerCursor_Find_no_match(t *testing.T) {
 	t.Parallel()
 
-	cursor := NewCustomLexerCursor(
+	cur := NewLexCursor(
 		NewCustomLexer(strings.NewReader("Hello\n!Find!"), &lexWordState{}),
 	)
 
-	if diff := cmp.Diff("", cursor.Find([]string{"no match"})); diff != "" {
+	if diff := cmp.Diff("", cur.Find([]string{"no match"})); diff != "" {
 		t.Errorf("Find (-want +got):\n%s", diff)
 	}
 
@@ -624,7 +624,7 @@ func TestCustomLexerCursor_Find_no_match(t *testing.T) {
 		Column: 7,
 	}
 
-	if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+	if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 		t.Errorf("Pos (-want +got):\n%s", diff)
 	}
 
@@ -634,19 +634,19 @@ func TestCustomLexerCursor_Find_no_match(t *testing.T) {
 		Column: 1,
 	}
 
-	if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+	if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 		t.Errorf("Cursor (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(12, cursor.Width()); diff != "" {
+	if diff := cmp.Diff(12, cur.Width()); diff != "" {
 		t.Errorf("Width (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff("Hello\n!Find!", cursor.Token()); diff != "" {
+	if diff := cmp.Diff("Hello\n!Find!", cur.Token()); diff != "" {
 		t.Errorf("Token (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Err (-want +got):\n%s", diff)
 	}
 }
@@ -657,15 +657,15 @@ func TestCustomLexerCursor_Ignore(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Ignore!\n"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff(7, cursor.AdvanceN(7)); diff != "" {
+		if diff := cmp.Diff(7, cur.AdvanceN(7)); diff != "" {
 			t.Errorf("AdvanceN (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Ignore!", string(cursor.PeekN(7))); diff != "" {
+		if diff := cmp.Diff("Ignore!", string(cur.PeekN(7))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -675,7 +675,7 @@ func TestCustomLexerCursor_Ignore(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -685,25 +685,25 @@ func TestCustomLexerCursor_Ignore(t *testing.T) {
 			Column: 1,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(7, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(7, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Hello\n!", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("Hello\n!", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		cursor.Ignore()
+		cur.Ignore()
 
-		if diff := cmp.Diff(7, cursor.AdvanceN(7)); diff != "" {
+		if diff := cmp.Diff(7, cur.AdvanceN(7)); diff != "" {
 			t.Errorf("AdvanceN (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("\n", string(cursor.PeekN(1))); diff != "" {
+		if diff := cmp.Diff("\n", string(cur.PeekN(1))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -713,7 +713,7 @@ func TestCustomLexerCursor_Ignore(t *testing.T) {
 			Column: 9,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -723,19 +723,19 @@ func TestCustomLexerCursor_Ignore(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(7, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(7, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Ignore!", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("Ignore!", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -748,15 +748,15 @@ func TestCustomLexerCursor_DiscardTo(t *testing.T) {
 	t.Run("match", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Find!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff("Find", cursor.DiscardTo([]string{"Find"})); diff != "" {
+		if diff := cmp.Diff("Find", cur.DiscardTo([]string{"Find"})); diff != "" {
 			t.Errorf("DiscardTo (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("Find!", string(cursor.PeekN(5))); diff != "" {
+		if diff := cmp.Diff("Find!", string(cur.PeekN(5))); diff != "" {
 			t.Errorf("PeekN (-want +got):\n%s", diff)
 		}
 
@@ -766,7 +766,7 @@ func TestCustomLexerCursor_DiscardTo(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -776,19 +776,19 @@ func TestCustomLexerCursor_DiscardTo(t *testing.T) {
 			Column: 2,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})
@@ -797,11 +797,11 @@ func TestCustomLexerCursor_DiscardTo(t *testing.T) {
 	t.Run("no match", func(t *testing.T) {
 		t.Parallel()
 
-		cursor := NewCustomLexerCursor(
+		cur := NewLexCursor(
 			NewCustomLexer(strings.NewReader("Hello\n!Find!"), &lexWordState{}),
 		)
 
-		if diff := cmp.Diff("", cursor.DiscardTo([]string{"no match"})); diff != "" {
+		if diff := cmp.Diff("", cur.DiscardTo([]string{"no match"})); diff != "" {
 			t.Errorf("DiscardTo (-want +got):\n%s", diff)
 		}
 
@@ -811,7 +811,7 @@ func TestCustomLexerCursor_DiscardTo(t *testing.T) {
 			Column: 7,
 		}
 
-		if diff := cmp.Diff(expectedPos, cursor.Pos()); diff != "" {
+		if diff := cmp.Diff(expectedPos, cur.Pos()); diff != "" {
 			t.Errorf("Pos (-want +got):\n%s", diff)
 		}
 
@@ -821,19 +821,19 @@ func TestCustomLexerCursor_DiscardTo(t *testing.T) {
 			Column: 7,
 		}
 
-		if diff := cmp.Diff(expectedCursor, cursor.Cursor()); diff != "" {
+		if diff := cmp.Diff(expectedCursor, cur.Cursor()); diff != "" {
 			t.Errorf("Cursor (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, cursor.Width()); diff != "" {
+		if diff := cmp.Diff(0, cur.Width()); diff != "" {
 			t.Errorf("Width (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff("", cursor.Token()); diff != "" {
+		if diff := cmp.Diff("", cur.Token()); diff != "" {
 			t.Errorf("Token (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(nil, cursor.l.Err(), cmpopts.EquateErrors()); diff != "" {
+		if diff := cmp.Diff(nil, cur.l.Err(), cmpopts.EquateErrors()); diff != "" {
 			t.Errorf("Err (-want +got):\n%s", diff)
 		}
 	})

--- a/infix_example_test.go
+++ b/infix_example_test.go
@@ -83,15 +83,16 @@ func tokenErr(err error, t *lexparse.Token) error {
 }
 
 // pratt implements a Pratt operator-precedence parser for infix expressions.
-func pratt(ctx *lexparse.ParserContext[*exprNode]) error {
-	n, err := parseExpr(ctx, 0, 0)
-	ctx.SetRoot(n)
+func pratt(ctx context.Context, cur *lexparse.ParseCursor[*exprNode]) error {
+	n, err := parseExpr(ctx, cur, 0, 0)
+	cur.SetRoot(n)
 
 	return err
 }
 
 func parseExpr(
-	ctx *lexparse.ParserContext[*exprNode],
+	ctx context.Context,
+	cur *lexparse.ParseCursor[*exprNode],
 	depth, minPrecedence int,
 ) (*lexparse.Node[*exprNode], error) {
 	// Check if the context is canceled.
@@ -102,7 +103,7 @@ func parseExpr(
 	default:
 	}
 
-	token := ctx.Next()
+	token := cur.Next(ctx)
 
 	var lhs *lexparse.Node[*exprNode]
 
@@ -113,20 +114,20 @@ func parseExpr(
 			return nil, tokenErr(err, token)
 		}
 
-		lhs = ctx.NewNode(&exprNode{
+		lhs = cur.NewNode(&exprNode{
 			typ: nodeTypeNum,
 			num: num,
 		})
 	case '(':
 		// Parse the expression inside the parentheses.
-		lhs2, err := parseExpr(ctx, depth+1, 0)
+		lhs2, err := parseExpr(ctx, cur, depth+1, 0)
 		if err != nil {
 			return nil, err
 		}
 
 		lhs = lhs2
 
-		t2 := ctx.Next()
+		t2 := cur.Next(ctx)
 		if t2.Type != ')' {
 			return nil, tokenErr(errUnclosedParen, t2)
 		}
@@ -140,7 +141,7 @@ outerL:
 	for {
 		var opVal *exprNode
 
-		opToken := ctx.Peek()
+		opToken := cur.Peek(ctx)
 		switch opToken.Type {
 		case '+', '-', '*', '/':
 			opVal = &exprNode{
@@ -165,10 +166,10 @@ outerL:
 			return lhs, nil
 		}
 
-		_ = ctx.Next() // Consume the operator token.
-		opNode := ctx.NewNode(opVal)
+		_ = cur.Next(ctx) // Consume the operator token.
+		opNode := cur.NewNode(opVal)
 
-		rhs, err := parseExpr(ctx, depth, opNode.Value.precedence())
+		rhs, err := parseExpr(ctx, cur, depth, opNode.Value.precedence())
 		if err != nil {
 			return nil, err
 		}

--- a/ini_example_test.go
+++ b/ini_example_test.go
@@ -87,12 +87,12 @@ var (
 // lexINI is the initial lexer state for INI files.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINI(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
+func lexINI(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
 	for {
-		rn := cursor.Peek()
+		rn := cur.Peek()
 		switch rn {
 		case ' ', '\t', '\r', '\n':
-			cursor.Discard()
+			cur.Discard()
 		case '[', ']', '=':
 			return lexparse.LexStateFn(lexINIOper), nil
 		case ';', '#':
@@ -108,9 +108,9 @@ func lexINI(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.Lex
 // lexINIOper lexes an operator token.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIOper(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
-	oper := cursor.NextRune()
-	cursor.Emit(lexINITypeOper)
+func lexINIOper(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
+	oper := cur.NextRune()
+	cur.Emit(lexINITypeOper)
 
 	if oper == '=' {
 		return lexparse.LexStateFn(lexINIValue), nil
@@ -122,9 +122,9 @@ func lexINIOper(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse
 // lexINIIden lexes an identifier token (section name or property key).
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIIden(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
-	if next := cursor.Find([]string{"]", "="}); next != "" {
-		cursor.Emit(lexINITypeIden)
+func lexINIIden(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
+	if next := cur.Find([]string{"]", "="}); next != "" {
+		cur.Emit(lexINITypeIden)
 		return lexparse.LexStateFn(lexINIOper), nil
 	}
 
@@ -134,9 +134,9 @@ func lexINIIden(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse
 // lexINIValue lexes a property value token.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIValue(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
-	cursor.Find([]string{";", "\n"})
-	cursor.Emit(lexINITypeValue)
+func lexINIValue(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
+	cur.Find([]string{";", "\n"})
+	cur.Emit(lexINITypeValue)
 
 	return lexparse.LexStateFn(lexINI), nil
 }
@@ -144,9 +144,9 @@ func lexINIValue(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexpars
 // lexINIComment lexes a comment token.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func lexINIComment(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
-	cursor.Find([]string{"\n"})
-	cursor.Emit(lexINITypeComment)
+func lexINIComment(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
+	cur.Find([]string{"\n"})
+	cur.Emit(lexINITypeComment)
 
 	return lexparse.LexStateFn(lexINI), nil
 }
@@ -158,35 +158,35 @@ func iniTokenErr(err error, t *lexparse.Token) error {
 }
 
 // parseINIInit is the initial parser state for INI files.
-func parseINIInit(ctx *lexparse.ParserContext[*iniNode]) error {
+func parseINIInit(_ context.Context, cur *lexparse.ParseCursor[*iniNode]) error {
 	// Replace the root node with a new root node.
-	_ = ctx.Replace(&iniNode{
+	_ = cur.Replace(&iniNode{
 		typ: iniNodeTypeRoot,
 	})
 
 	// Create the empty section node for the global section.
-	_ = ctx.Push(&iniNode{
+	_ = cur.Push(&iniNode{
 		typ:         iniNodeTypeSection,
 		sectionName: "",
 	})
 
-	ctx.PushState(lexparse.ParseStateFn(parseINI))
+	cur.PushState(lexparse.ParseStateFn(parseINI))
 
 	return nil
 }
 
 // parseINI parses the top-level structure of an INI file.
-func parseINI(ctx *lexparse.ParserContext[*iniNode]) error {
-	t := ctx.Peek()
+func parseINI(ctx context.Context, cur *lexparse.ParseCursor[*iniNode]) error {
+	t := cur.Peek(ctx)
 
 	switch t.Type {
 	case lexINITypeOper:
-		ctx.PushState(lexparse.ParseStateFn(parseSection))
+		cur.PushState(lexparse.ParseStateFn(parseSection))
 	case lexINITypeIden:
-		ctx.PushState(lexparse.ParseStateFn(parseProperty))
+		cur.PushState(lexparse.ParseStateFn(parseProperty))
 	case lexINITypeComment:
-		_ = ctx.Next() // Discard comment
-		ctx.PushState(lexparse.ParseStateFn(parseINI))
+		_ = cur.Next(ctx) // Discard comment
+		cur.PushState(lexparse.ParseStateFn(parseINI))
 	case lexparse.TokenTypeEOF:
 		return nil
 	default:
@@ -197,18 +197,18 @@ func parseINI(ctx *lexparse.ParserContext[*iniNode]) error {
 }
 
 // parseSection parses a section header.
-func parseSection(ctx *lexparse.ParserContext[*iniNode]) error {
-	openBracket := ctx.Next()
+func parseSection(ctx context.Context, cur *lexparse.ParseCursor[*iniNode]) error {
+	openBracket := cur.Next(ctx)
 	if openBracket.Type != lexINITypeOper || openBracket.Value != "[" {
 		return iniTokenErr(errINIIdentifier, openBracket)
 	}
 
-	sectionToken := ctx.Next()
+	sectionToken := cur.Next(ctx)
 	if sectionToken.Type != lexINITypeIden {
 		return iniTokenErr(errINIIdentifier, sectionToken)
 	}
 
-	closeBracket := ctx.Next()
+	closeBracket := cur.Next(ctx)
 	if closeBracket.Type != lexINITypeOper || closeBracket.Value != "]" {
 		return iniTokenErr(errINIIdentifier, closeBracket)
 	}
@@ -222,20 +222,20 @@ func parseSection(ctx *lexparse.ParserContext[*iniNode]) error {
 
 	// Create a new node for the section and push it onto the parse tree.
 	// The current node is now the new section node.
-	_ = ctx.Climb()
-	_ = ctx.Push(&iniNode{
+	_ = cur.Climb()
+	_ = cur.Push(&iniNode{
 		typ:         iniNodeTypeSection,
 		sectionName: sectionName,
 	})
 
-	ctx.PushState(lexparse.ParseStateFn(parseINI))
+	cur.PushState(lexparse.ParseStateFn(parseINI))
 
 	return nil
 }
 
 // parseProperty parses a property key-value pair.
-func parseProperty(ctx *lexparse.ParserContext[*iniNode]) error {
-	keyToken := ctx.Next()
+func parseProperty(ctx context.Context, cur *lexparse.ParseCursor[*iniNode]) error {
+	keyToken := cur.Next(ctx)
 	if keyToken.Type != lexINITypeIden {
 		return iniTokenErr(errINIIdentifier, keyToken)
 	}
@@ -247,24 +247,24 @@ func parseProperty(ctx *lexparse.ParserContext[*iniNode]) error {
 		return iniTokenErr(errINIPropertyName, keyToken)
 	}
 
-	eqToken := ctx.Next()
+	eqToken := cur.Next(ctx)
 	if eqToken.Type != lexINITypeOper || eqToken.Value != "=" {
 		return iniTokenErr(errINIIdentifier, eqToken)
 	}
 
-	valueToken := ctx.Next()
+	valueToken := cur.Next(ctx)
 	if valueToken.Type != lexINITypeValue {
 		return iniTokenErr(errINIIdentifier, valueToken)
 	}
 
 	// Create a new node for the property and add it to the current section.
-	ctx.Node(&iniNode{
+	cur.Node(&iniNode{
 		typ:           iniNodeTypeProperty,
 		propertyName:  keyName,
 		propertyValue: strings.TrimSpace(valueToken.Value),
 	})
 
-	ctx.PushState(lexparse.ParseStateFn(parseINI))
+	cur.PushState(lexparse.ParseStateFn(parseINI))
 
 	return nil
 }

--- a/lexparse_test.go
+++ b/lexparse_test.go
@@ -26,11 +26,11 @@ import (
 
 type parseTokenState struct{}
 
-func (w *parseTokenState) Run(ctx *ParserContext[string]) error {
-	switch token := ctx.Next(); token.Type {
+func (w *parseTokenState) Run(ctx context.Context, cur *ParseCursor[string]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case TokenTypeIdent:
-		ctx.Node(token.Value)
-		ctx.PushState(w)
+		cur.Node(token.Value)
+		cur.PushState(w)
 
 		return nil
 	case TokenTypeEOF:
@@ -93,11 +93,11 @@ func TestScannerLexParse(t *testing.T) {
 
 type parseWordState struct{}
 
-func (w *parseWordState) Run(ctx *ParserContext[string]) error {
-	switch token := ctx.Next(); token.Type {
+func (w *parseWordState) Run(ctx context.Context, cur *ParseCursor[string]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case wordType:
-		ctx.Node(token.Value)
-		ctx.PushState(w)
+		cur.Node(token.Value)
+		cur.PushState(w)
 
 		return nil
 	case TokenTypeEOF:
@@ -115,14 +115,14 @@ var (
 type lexErrState struct{}
 
 //nolint:ireturn // returning interface is required to satisfy LexState.
-func (e *lexErrState) Run(context.Context, *CustomLexerCursor) (LexState, error) {
+func (e *lexErrState) Run(context.Context, *LexCursor) (LexState, error) {
 	return nil, errState
 }
 
 type parseErrState struct{}
 
-func (e *parseErrState) Run(ctx *ParserContext[string]) error {
-	_ = ctx.Next()
+func (e *parseErrState) Run(ctx context.Context, cur *ParseCursor[string]) error {
+	_ = cur.Next(ctx)
 	return errParse
 }
 

--- a/parser.go
+++ b/parser.go
@@ -74,24 +74,24 @@ type ParseState[V comparable] interface {
 	// encountered. Implementations are expected to add new [Node] objects to
 	// the AST using [Parser.Push] or [Parser.Node). As necessary, new parser
 	// state should be pushed onto the stack as needed using [Parser.PushState].
-	Run(ctx *ParserContext[V]) error
+	Run(ctx context.Context, cur *ParseCursor[V]) error
 }
 
 type parseFnState[V comparable] struct {
-	f func(*ParserContext[V]) error
+	f func(context.Context, *ParseCursor[V]) error
 }
 
 // Run implements ParseState.Run.
-func (s *parseFnState[V]) Run(ctx *ParserContext[V]) error {
+func (s *parseFnState[V]) Run(ctx context.Context, cur *ParseCursor[V]) error {
 	if s.f == nil {
 		return nil
 	}
 
-	return s.f(ctx)
+	return s.f(ctx, cur)
 }
 
 // ParseStateFn creates a State from the given Run function.
-func ParseStateFn[V comparable](f func(*ParserContext[V]) error) ParseState[V] {
+func ParseStateFn[V comparable](f func(context.Context, *ParseCursor[V]) error) ParseState[V] {
 	return &parseFnState[V]{f}
 }
 
@@ -119,74 +119,76 @@ type TokenSource interface {
 	NextToken(ctx context.Context) *Token
 }
 
-// ParserContext provides context for the current parsing operation,
-// including access to the parser state and methods to manipulate the parse
-// tree.
-type ParserContext[V comparable] struct {
-	//nolint:containedctx // Embedding context required for interface compliance.
-	context.Context
-
+// ParseCursor is a type that allows for processing input tokens and building a
+// parse tree. It is passed to [ParseState.Run] and provides methods for
+// manipulating the parser state and the parse tree.
+type ParseCursor[V comparable] struct {
 	p *Parser[V]
+}
+
+// NewParseCursor creates a new ParserCursor for the given parser.
+func NewParseCursor[V comparable](p *Parser[V]) *ParseCursor[V] {
+	return &ParseCursor[V]{p: p}
 }
 
 // PushState pushes a number of new expected future states onto the state stack
 // in reverse order.
-func (ctx *ParserContext[V]) PushState(states ...ParseState[V]) {
-	ctx.p.pushState(states...)
+func (cur *ParseCursor[V]) PushState(states ...ParseState[V]) {
+	cur.p.pushState(states...)
 }
 
 // SetRoot sets the root of the parse tree to the given node. The current node
 // is also set to the root node. This is useful for resetting the parser to a
 // new root node.
-func (ctx *ParserContext[V]) SetRoot(root *Node[V]) {
-	ctx.p.setRoot(root)
+func (cur *ParseCursor[V]) SetRoot(root *Node[V]) {
+	cur.p.setRoot(root)
 }
 
 // Root returns the root of the parse tree.
-func (ctx *ParserContext[V]) Root() *Node[V] {
-	return ctx.p.root
+func (cur *ParseCursor[V]) Root() *Node[V] {
+	return cur.p.root
 }
 
 // Peek returns the next token from the lexer without consuming it.
-func (ctx *ParserContext[V]) Peek() *Token {
-	return ctx.p.peek(ctx)
+func (cur *ParseCursor[V]) Peek(ctx context.Context) *Token {
+	return cur.p.peek(ctx)
 }
 
 // Next returns the next token from the lexer. This is the new current token
 // position.
-func (ctx *ParserContext[V]) Next() *Token {
-	return ctx.p.nextToken(ctx)
+func (cur *ParseCursor[V]) Next(ctx context.Context) *Token {
+	return cur.p.nextToken(ctx)
 }
 
 // Pos returns the current node position in the tree.
-func (ctx *ParserContext[V]) Pos() *Node[V] {
-	return ctx.p.node
+func (cur *ParseCursor[V]) Pos() *Node[V] {
+	return cur.p.node
 }
 
 // Push creates a new node, adds it as a child to the current node, updates
 // the current node to the new node, and returns the new node.
-func (ctx *ParserContext[V]) Push(v V) *Node[V] {
-	return ctx.p.push(v)
+func (cur *ParseCursor[V]) Push(v V) *Node[V] {
+	return cur.p.push(v)
 }
 
 // Node creates a new node at the current token position and adds it as a
 // child to the current node. The current node is not updated.
-func (ctx *ParserContext[V]) Node(v V) *Node[V] {
-	return ctx.p.addNodeHere(v)
+func (cur *ParseCursor[V]) Node(v V) *Node[V] {
+	return cur.p.addNodeHere(v)
 }
 
 // NewNode creates a new node at the current token position and returns it
 // without adding it to the tree.
-func (ctx *ParserContext[V]) NewNode(v V) *Node[V] {
-	return ctx.p.newNode(v)
+func (cur *ParseCursor[V]) NewNode(v V) *Node[V] {
+	return cur.p.newNode(v)
 }
 
 // Climb updates the current node position to the current node's parent
 // returning the previous current node. It is a no-op that returns the root
 // node if called on the root node. Updates the end position of the parent node
 // to the end position of the current node.
-func (ctx *ParserContext[V]) Climb() *Node[V] {
-	return ctx.p.climb()
+func (cur *ParseCursor[V]) Climb() *Node[V] {
+	return cur.p.climb()
 }
 
 // Replace replaces the current node with a new node with the given value. The
@@ -194,8 +196,8 @@ func (ctx *ParserContext[V]) Climb() *Node[V] {
 // replace the root node.
 //
 //nolint:ireturn // returning the generic interface is needed to return the previous value.
-func (ctx *ParserContext[V]) Replace(v V) V {
-	return ctx.p.replace(v)
+func (cur *ParseCursor[V]) Replace(v V) V {
+	return cur.p.replace(v)
 }
 
 // NewParser creates a new Parser that reads from the tokens channel. The
@@ -252,10 +254,7 @@ type Parser[V comparable] struct {
 //
 // The caller can request that the parser stop by canceling ctx.
 func (p *Parser[V]) Parse(ctx context.Context) (*Node[V], error) {
-	parserCtx := &ParserContext[V]{
-		Context: ctx,
-		p:       p,
-	}
+	cur := NewParseCursor(p)
 
 	for {
 		state := p.stateStack.pop()
@@ -275,7 +274,7 @@ func (p *Parser[V]) Parse(ctx context.Context) (*Node[V], error) {
 		}
 
 		var err error
-		if err = state.Run(parserCtx); err != nil {
+		if err = state.Run(ctx, cur); err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}

--- a/parser.go
+++ b/parser.go
@@ -71,9 +71,10 @@ func fmtNode[V comparable](node *Node[V], lastRank []bool) string {
 // logic to process the current state and returns the next state.
 type ParseState[V comparable] interface {
 	// Run executes the logic at the current state, returning an error if one is
-	// encountered. Implementations are expected to add new [Node] objects to
-	// the AST using [Parser.Push] or [Parser.Node). As necessary, new parser
-	// state should be pushed onto the stack as needed using [Parser.PushState].
+	// encountered. Implementations are expected to add new Node objects to
+	// the AST using ParseCursor.Push or ParseCursor.Node. As necessary, new
+	// parser state should be pushed onto the stack as needed using
+	// Parser.PushState.
 	Run(ctx context.Context, cur *ParseCursor[V]) error
 }
 
@@ -81,7 +82,7 @@ type parseFnState[V comparable] struct {
 	f func(context.Context, *ParseCursor[V]) error
 }
 
-// Run implements ParseState.Run.
+// Run implements [ParseState.Run].
 func (s *parseFnState[V]) Run(ctx context.Context, cur *ParseCursor[V]) error {
 	if s.f == nil {
 		return nil
@@ -90,7 +91,7 @@ func (s *parseFnState[V]) Run(ctx context.Context, cur *ParseCursor[V]) error {
 	return s.f(ctx, cur)
 }
 
-// ParseStateFn creates a State from the given Run function.
+// ParseStateFn creates a State from the given function.
 func ParseStateFn[V comparable](f func(context.Context, *ParseCursor[V]) error) ParseState[V] {
 	return &parseFnState[V]{f}
 }
@@ -126,7 +127,7 @@ type ParseCursor[V comparable] struct {
 	p *Parser[V]
 }
 
-// NewParseCursor creates a new ParserCursor for the given parser.
+// NewParseCursor creates a new [ParseCursor] for the given parser.
 func NewParseCursor[V comparable](p *Parser[V]) *ParseCursor[V] {
 	return &ParseCursor[V]{p: p}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -163,7 +163,7 @@ func TestParser_parse_op2(t *testing.T) {
 	}
 }
 
-func TestParserContext_NextPeek(t *testing.T) {
+func TestParseCursor_NextPeek(t *testing.T) {
 	t.Parallel()
 
 	input := "A B C"
@@ -262,7 +262,7 @@ func TestParserContext_NextPeek(t *testing.T) {
 	}
 }
 
-func TestParserContext_Node(t *testing.T) {
+func TestParseCursor_Node(t *testing.T) {
 	t.Parallel()
 
 	parser := NewParser[string](nil, nil)
@@ -320,7 +320,7 @@ func TestParserContext_Node(t *testing.T) {
 	}
 }
 
-func TestParserContext_ClimbPos(t *testing.T) {
+func TestParseCursor_ClimbPos(t *testing.T) {
 	t.Parallel()
 
 	parser := NewParser[string](nil, nil)
@@ -388,7 +388,7 @@ func TestParserContext_ClimbPos(t *testing.T) {
 	}
 }
 
-func TestParserContext_Push(t *testing.T) {
+func TestParseCursor_Push(t *testing.T) {
 	t.Parallel()
 
 	parser := NewParser[string](nil, nil)
@@ -503,7 +503,7 @@ func TestParser_Replace(t *testing.T) {
 	}
 }
 
-func TestParserContext_Replace_root(t *testing.T) {
+func TestParseCursor_Replace_root(t *testing.T) {
 	t.Parallel()
 
 	parser := NewParser[string](nil, nil)

--- a/parser_test.go
+++ b/parser_test.go
@@ -40,9 +40,9 @@ func testParse(t *testing.T, input string) (*Node[string], error) {
 
 	l := NewCustomLexer(strings.NewReader(input), &lexWordState{})
 
-	parser := NewParser(l, ParseStateFn(func(ctx *ParserContext[string]) error {
+	parser := NewParser(l, ParseStateFn(func(ctx context.Context, cur *ParseCursor[string]) error {
 		for {
-			token := ctx.Next()
+			token := cur.Next(ctx)
 			switch token.Type {
 			case wordType:
 				// OK
@@ -55,13 +55,13 @@ func testParse(t *testing.T, input string) (*Node[string], error) {
 			switch token.Value {
 			case "climb":
 				// Climb the tree without adding a node.
-				_ = ctx.Climb()
+				_ = cur.Climb()
 			case "replace":
-				_ = ctx.Replace(token.Value)
+				_ = cur.Replace(token.Value)
 			case "push":
-				_ = ctx.Push(token.Value)
+				_ = cur.Push(token.Value)
 			default:
-				ctx.Node(token.Value)
+				cur.Node(token.Value)
 			}
 		}
 	}))
@@ -169,13 +169,12 @@ func TestParserContext_NextPeek(t *testing.T) {
 	input := "A B C"
 	l := NewCustomLexer(strings.NewReader(input), &lexWordState{})
 
-	ctx := &ParserContext[string]{
-		Context: context.Background(),
-		p:       NewParser[string](l, nil),
-	}
+	parser := NewParser[string](l, nil)
+	cur := NewParseCursor[string](parser)
+	ctx := t.Context()
 
 	// Expect to read the first token `A`
-	tokenA := ctx.Next()
+	tokenA := cur.Next(ctx)
 
 	wanttokenA := &Token{
 		Type:  wordType,
@@ -195,7 +194,7 @@ func TestParserContext_NextPeek(t *testing.T) {
 		t.Fatalf("Next: (-want, +got): \n%s", diff)
 	}
 
-	peekTokenB := ctx.Peek()
+	peekTokenB := cur.Peek(ctx)
 
 	wantTokenB := &Token{
 		Type:  wordType,
@@ -216,12 +215,12 @@ func TestParserContext_NextPeek(t *testing.T) {
 	}
 
 	// Expect to read the second token "B" because it was not consumed
-	tokenB := ctx.Next()
+	tokenB := cur.Next(ctx)
 	if diff := cmp.Diff(wantTokenB, tokenB); diff != "" {
 		t.Fatalf("Peek: (-want, +got): \n%s", diff)
 	}
 
-	tokenC := ctx.Next()
+	tokenC := cur.Next(ctx)
 
 	wantTokenC := &Token{
 		Type:  wordType,
@@ -242,7 +241,7 @@ func TestParserContext_NextPeek(t *testing.T) {
 	}
 
 	// The expected end of tokens
-	niltoken := ctx.Next()
+	niltoken := cur.Next(ctx)
 
 	tokenEOF := &Token{
 		Type:  TokenTypeEOF,
@@ -266,12 +265,10 @@ func TestParserContext_NextPeek(t *testing.T) {
 func TestParserContext_Node(t *testing.T) {
 	t.Parallel()
 
-	ctx := &ParserContext[string]{
-		Context: context.Background(),
-		p:       NewParser[string](nil, nil),
-	}
+	parser := NewParser[string](nil, nil)
+	cur := NewParseCursor[string](parser)
 
-	child1 := ctx.Node("A")
+	child1 := cur.Node("A")
 	expectedRootA := addParent(&Node[string]{
 		Start: Position{
 			Offset: 0,
@@ -289,11 +286,11 @@ func TestParserContext_Node(t *testing.T) {
 		t.Fatalf("Node: (-want, +got): \n%s", diff)
 	}
 	// Current node is still set to root.
-	if diff := cmp.Diff(ctx.p.root, ctx.p.node); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.p.node); diff != "" {
 		t.Errorf("p.node: (-want, +got): \n%s", diff)
 	}
 
-	child2 := ctx.Node("B")
+	child2 := cur.Node("B")
 	expectedRootB := addParent(&Node[string]{
 		Start: Position{
 			Offset: 0,
@@ -314,11 +311,11 @@ func TestParserContext_Node(t *testing.T) {
 		t.Fatalf("Node: (-want, +got): \n%s", diff)
 	}
 	// Current node is still set to root.
-	if diff := cmp.Diff(ctx.p.root, ctx.p.node); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.p.node); diff != "" {
 		t.Errorf("p.node: (-want, +got): \n%s", diff)
 	}
 
-	if diff := cmp.Diff(expectedRootB, ctx.p.root); diff != "" {
+	if diff := cmp.Diff(expectedRootB, cur.p.root); diff != "" {
 		t.Fatalf("Node: parser.root (-want, +got): \n%s", diff)
 	}
 }
@@ -326,12 +323,10 @@ func TestParserContext_Node(t *testing.T) {
 func TestParserContext_ClimbPos(t *testing.T) {
 	t.Parallel()
 
-	ctx := &ParserContext[string]{
-		Context: context.Background(),
-		p:       NewParser[string](nil, nil),
-	}
+	parser := NewParser[string](nil, nil)
+	cur := NewParseCursor[string](parser)
 
-	ctx.p.root = addParent(
+	cur.p.root = addParent(
 		&Node[string]{
 			Start: Position{
 				Offset: 0,
@@ -351,44 +346,44 @@ func TestParserContext_ClimbPos(t *testing.T) {
 		},
 	)
 	// Current node is Node B
-	ctx.p.node = ctx.p.root.Children[0].Children[0]
+	cur.p.node = cur.p.root.Children[0].Children[0]
 
 	// Climb returns Node B
-	if diff := cmp.Diff(ctx.p.root.Children[0].Children[0], ctx.Climb()); diff != "" {
+	if diff := cmp.Diff(cur.p.root.Children[0].Children[0], cur.Climb()); diff != "" {
 		t.Errorf("Climb: (-want, +got): \n%s", diff)
 	}
 	// Current node is set to Node A
-	if diff := cmp.Diff(ctx.p.root.Children[0], ctx.p.node); diff != "" {
+	if diff := cmp.Diff(cur.p.root.Children[0], cur.p.node); diff != "" {
 		t.Errorf("parser.node: (-want, +got): \n%s", diff)
 	}
 	// Pos returns Node A
-	if diff := cmp.Diff(ctx.p.root.Children[0], ctx.Pos()); diff != "" {
+	if diff := cmp.Diff(cur.p.root.Children[0], cur.Pos()); diff != "" {
 		t.Errorf("Pos: (-want, +got): \n%s", diff)
 	}
 
 	// Climb returns Node A
-	if diff := cmp.Diff(ctx.p.root.Children[0], ctx.Climb()); diff != "" {
+	if diff := cmp.Diff(cur.p.root.Children[0], cur.Climb()); diff != "" {
 		t.Errorf("Climb: (-want, +got): \n%s", diff)
 	}
 	// Current node is set to root node.
-	if diff := cmp.Diff(ctx.p.root, ctx.p.node); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.p.node); diff != "" {
 		t.Errorf("parser.node (-want, +got): \n%s", diff)
 	}
 	// Pos returns root node.
-	if diff := cmp.Diff(ctx.p.root, ctx.Pos()); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.Pos()); diff != "" {
 		t.Errorf("Pos: (-want, +got): \n%s", diff)
 	}
 
 	// Climb returns root node.
-	if diff := cmp.Diff(ctx.p.root, ctx.Climb()); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.Climb()); diff != "" {
 		t.Errorf("Climb: (-want, +got): \n%s", diff)
 	}
 	// Current node is set to root node.
-	if diff := cmp.Diff(ctx.p.root, ctx.p.node); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.p.node); diff != "" {
 		t.Errorf("parser.node (-want, +got): \n%s", diff)
 	}
 	// Pos returns root node.
-	if diff := cmp.Diff(ctx.p.root, ctx.Pos()); diff != "" {
+	if diff := cmp.Diff(cur.p.root, cur.Pos()); diff != "" {
 		t.Errorf("Pos: (-want, +got): \n%s", diff)
 	}
 }
@@ -396,10 +391,8 @@ func TestParserContext_ClimbPos(t *testing.T) {
 func TestParserContext_Push(t *testing.T) {
 	t.Parallel()
 
-	ctx := &ParserContext[string]{
-		Context: context.Background(),
-		p:       NewParser[string](nil, nil),
-	}
+	parser := NewParser[string](nil, nil)
+	cur := NewParseCursor[string](parser)
 
 	valA := "A"
 
@@ -415,15 +408,15 @@ func TestParserContext_Push(t *testing.T) {
 			},
 		},
 	})
-	if diff := cmp.Diff(expectedRootA.Children[0], ctx.Push(valA)); diff != "" {
+	if diff := cmp.Diff(expectedRootA.Children[0], cur.Push(valA)); diff != "" {
 		t.Errorf("Push(%q): (-want, +got): \n%s", valA, diff)
 	}
 
-	if diff := cmp.Diff(expectedRootA.Children[0], ctx.p.node); diff != "" {
+	if diff := cmp.Diff(expectedRootA.Children[0], cur.p.node); diff != "" {
 		t.Errorf("p.node (-want, +got): \n%s", diff)
 	}
 
-	if diff := cmp.Diff(expectedRootA, ctx.p.root); diff != "" {
+	if diff := cmp.Diff(expectedRootA, cur.p.root); diff != "" {
 		t.Errorf("parser.root (-want, +got): \n%s", diff)
 	}
 
@@ -446,15 +439,15 @@ func TestParserContext_Push(t *testing.T) {
 			},
 		},
 	})
-	if diff := cmp.Diff(expectedRootB.Children[0].Children[0], ctx.Push(valB)); diff != "" {
+	if diff := cmp.Diff(expectedRootB.Children[0].Children[0], cur.Push(valB)); diff != "" {
 		t.Errorf("Push(%q): (-want, +got): \n%s", valB, diff)
 	}
 
-	if diff := cmp.Diff(expectedRootB.Children[0].Children[0], ctx.p.node); diff != "" {
+	if diff := cmp.Diff(expectedRootB.Children[0].Children[0], cur.p.node); diff != "" {
 		t.Errorf("parser.node (-want, +got): \n%s", diff)
 	}
 
-	if diff := cmp.Diff(expectedRootB, ctx.p.root); diff != "" {
+	if diff := cmp.Diff(expectedRootB, cur.p.root); diff != "" {
 		t.Errorf("parser.root (-want, +got): \n%s", diff)
 	}
 }
@@ -462,12 +455,10 @@ func TestParserContext_Push(t *testing.T) {
 func TestParser_Replace(t *testing.T) {
 	t.Parallel()
 
-	ctx := &ParserContext[string]{
-		Context: context.Background(),
-		p:       NewParser[string](nil, nil),
-	}
+	parser := NewParser[string](nil, nil)
+	cur := NewParseCursor[string](parser)
 
-	ctx.p.root = addParent(&Node[string]{
+	cur.p.root = addParent(&Node[string]{
 		Children: []*Node[string]{
 			{
 				Value: "A",
@@ -481,11 +472,11 @@ func TestParser_Replace(t *testing.T) {
 	})
 
 	// Current node is Node A
-	ctx.p.node = ctx.p.root.Children[0]
+	cur.p.node = cur.p.root.Children[0]
 
 	// Replace Node A with C
 	valC := "C"
-	if diff := cmp.Diff("A", ctx.Replace(valC)); diff != "" {
+	if diff := cmp.Diff("A", cur.Replace(valC)); diff != "" {
 		t.Errorf("Replace(%q): (-want, +got): \n%s", valC, diff)
 	}
 
@@ -503,11 +494,11 @@ func TestParser_Replace(t *testing.T) {
 	})
 
 	// Current node is set to Node `C`.
-	if diff := cmp.Diff(expectedRoot.Children[0], ctx.p.node); diff != "" {
+	if diff := cmp.Diff(expectedRoot.Children[0], cur.p.node); diff != "" {
 		t.Errorf("p.node (-want, +got): \n%s", diff)
 	}
 	// Full tree has expected values.
-	if diff := cmp.Diff(expectedRoot, ctx.p.root); diff != "" {
+	if diff := cmp.Diff(expectedRoot, cur.p.root); diff != "" {
 		t.Errorf("parser.root (-want, +got): \n%s", diff)
 	}
 }
@@ -515,14 +506,12 @@ func TestParser_Replace(t *testing.T) {
 func TestParserContext_Replace_root(t *testing.T) {
 	t.Parallel()
 
-	ctx := &ParserContext[string]{
-		Context: context.Background(),
-		p:       NewParser[string](nil, nil),
-	}
+	parser := NewParser[string](nil, nil)
+	cur := NewParseCursor[string](parser)
 
 	// Replace root node with A
 	valA := "A"
-	if diff := cmp.Diff("", ctx.Replace(valA)); diff != "" {
+	if diff := cmp.Diff("", cur.Replace(valA)); diff != "" {
 		t.Errorf("Replace(%q): (-want, +got): \n%s", valA, diff)
 	}
 
@@ -531,11 +520,11 @@ func TestParserContext_Replace_root(t *testing.T) {
 	}
 
 	// Current node is set to root node.
-	if diff := cmp.Diff(expectedRoot, ctx.p.node); diff != "" {
+	if diff := cmp.Diff(expectedRoot, cur.p.node); diff != "" {
 		t.Errorf("p.node (-want, +got): \n%s", diff)
 	}
 	// Full tree has expected values.
-	if diff := cmp.Diff(expectedRoot, ctx.p.root); diff != "" {
+	if diff := cmp.Diff(expectedRoot, cur.p.root); diff != "" {
 		t.Errorf("p.root (-want, +got): \n%s", diff)
 	}
 }

--- a/template_example_test.go
+++ b/template_example_test.go
@@ -106,22 +106,22 @@ func lexTokenErr(err error, t *lexparse.Token) error {
 // lexText tokenizes normal text.
 //
 //nolint:ireturn // returning interface is required to satisfy lexparse.LexState.
-func lexText(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
+func lexText(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
 	for {
-		p := string(cursor.PeekN(2))
+		p := string(cur.PeekN(2))
 		if p == tokenBlockStart || p == tokenVarStart {
-			if cursor.Width() > 0 {
-				cursor.Emit(lexTypeText)
+			if cur.Width() > 0 {
+				cur.Emit(lexTypeText)
 			}
 
 			return lexparse.LexStateFn(lexCode), nil
 		}
 
 		// Advance the input.
-		if !cursor.Advance() {
+		if !cur.Advance() {
 			// End of input. Emit the text up to this point.
-			if cursor.Width() > 0 {
-				cursor.Emit(lexTypeText)
+			if cur.Width() > 0 {
+				cur.Emit(lexTypeText)
 			}
 
 			return nil, io.EOF
@@ -132,17 +132,17 @@ func lexText(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.Le
 // lexCode tokenizes template code.
 //
 //nolint:ireturn // returning interface is required to satisfy lexparse.LexState.
-func lexCode(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
+func lexCode(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
 	// Consume whitespace and discard it.
 	// TODO(#94): use backtracking
-	for unicode.IsSpace(cursor.Peek()) {
-		if !cursor.Discard() {
+	for unicode.IsSpace(cur.Peek()) {
+		if !cur.Discard() {
 			// End of input
 			return nil, io.EOF
 		}
 	}
 
-	rn := cursor.Peek()
+	rn := cur.Peek()
 	switch {
 	case idenRegexp.MatchString(string(rn)):
 		return lexparse.LexStateFn(lexIden), nil
@@ -150,21 +150,21 @@ func lexCode(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.Le
 		return lexparse.LexStateFn(lexSymbol), nil
 	default:
 		return nil, fmt.Errorf("%w: %q; line: %d, column: %d", errRune,
-			rn, cursor.Pos().Line, cursor.Pos().Column)
+			rn, cur.Pos().Line, cur.Pos().Column)
 	}
 }
 
 // lexIden tokenizes identifiers (e.g. variable names).
 //
 //nolint:ireturn // returning interface is required to satisfy lexparse.LexState.
-func lexIden(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
+func lexIden(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
 	for {
-		if rn := cursor.Peek(); !idenRegexp.MatchString(string(rn)) {
-			cursor.Emit(lexTypeIdentifier)
+		if rn := cur.Peek(); !idenRegexp.MatchString(string(rn)) {
+			cur.Emit(lexTypeIdentifier)
 			return lexparse.LexStateFn(lexCode), nil
 		}
 
-		if !cursor.Advance() {
+		if !cur.Advance() {
 			return nil, io.EOF
 		}
 	}
@@ -173,56 +173,56 @@ func lexIden(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.Le
 // lexSymbol tokenizes template symbols (e.g. {%, {{, }}, %}).
 //
 //nolint:ireturn // returning interface is required to satisfy lexparse.LexState.
-func lexSymbol(_ context.Context, cursor *lexparse.CustomLexerCursor) (lexparse.LexState, error) {
+func lexSymbol(_ context.Context, cur *lexparse.LexCursor) (lexparse.LexState, error) {
 	for {
-		switch cursor.Token() {
+		switch cur.Token() {
 		case tokenVarStart:
-			cursor.Emit(lexTypeVarStart)
+			cur.Emit(lexTypeVarStart)
 			return lexparse.LexStateFn(lexCode), nil
 		case tokenVarEnd:
-			cursor.Emit(lexTypeVarEnd)
+			cur.Emit(lexTypeVarEnd)
 			return lexparse.LexStateFn(lexText), nil
 		case tokenBlockStart:
-			cursor.Emit(lexTypeBlockStart)
+			cur.Emit(lexTypeBlockStart)
 			return lexparse.LexStateFn(lexCode), nil
 		case tokenBlockEnd:
-			cursor.Emit(lexTypeBlockEnd)
+			cur.Emit(lexTypeBlockEnd)
 			return lexparse.LexStateFn(lexText), nil
 		default:
-			if rn := cursor.Peek(); !symbolRegexp.MatchString(string(rn)) {
+			if rn := cur.Peek(); !symbolRegexp.MatchString(string(rn)) {
 				return nil, fmt.Errorf("symbol: %w: %q; line: %d, column: %d",
-					errRune, rn, cursor.Pos().Line, cursor.Pos().Column)
+					errRune, rn, cur.Pos().Line, cur.Pos().Column)
 			}
 		}
 
-		if !cursor.Advance() {
+		if !cur.Advance() {
 			return nil, io.EOF
 		}
 	}
 }
 
 // parseRoot updates the root node to be a sequence block.
-func parseRoot(ctx *lexparse.ParserContext[*tmplNode]) error {
-	ctx.Replace(&tmplNode{
+func parseRoot(_ context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	cur.Replace(&tmplNode{
 		typ: nodeTypeSeq,
 	})
 
-	ctx.PushState(lexparse.ParseStateFn(parseSeq))
+	cur.PushState(lexparse.ParseStateFn(parseSeq))
 
 	return nil
 }
 
 // parseSeq delegates to another parse function based on token type.
-func parseSeq(ctx *lexparse.ParserContext[*tmplNode]) error {
-	token := ctx.Peek()
+func parseSeq(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	token := cur.Peek(ctx)
 
 	switch token.Type {
 	case lexTypeText:
-		ctx.PushState(lexparse.ParseStateFn(parseText))
+		cur.PushState(lexparse.ParseStateFn(parseText))
 	case lexTypeVarStart:
-		ctx.PushState(lexparse.ParseStateFn(parseVarStart))
+		cur.PushState(lexparse.ParseStateFn(parseVarStart))
 	case lexTypeBlockStart:
-		ctx.PushState(lexparse.ParseStateFn(parseBlockStart))
+		cur.PushState(lexparse.ParseStateFn(parseBlockStart))
 	default:
 	}
 
@@ -230,27 +230,27 @@ func parseSeq(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseText handles normal text.
-func parseText(ctx *lexparse.ParserContext[*tmplNode]) error {
-	token := ctx.Next()
+func parseText(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	token := cur.Next(ctx)
 
 	// Emit a text node.
-	ctx.Node(&tmplNode{
+	cur.Node(&tmplNode{
 		typ:  nodeTypeText,
 		text: token.Value,
 	})
 
 	// Return to handling a sequence.
-	ctx.PushState(lexparse.ParseStateFn(parseSeq))
+	cur.PushState(lexparse.ParseStateFn(parseSeq))
 
 	return nil
 }
 
 // parseVarStart handles var start (e.g. '{{').
-func parseVarStart(ctx *lexparse.ParserContext[*tmplNode]) error {
+func parseVarStart(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
 	// Consume the var start token.
-	_ = ctx.Next()
+	_ = cur.Next(ctx)
 
-	ctx.PushState(
+	cur.PushState(
 		lexparse.ParseStateFn(parseVar),
 		lexparse.ParseStateFn(parseVarEnd),
 	)
@@ -259,8 +259,8 @@ func parseVarStart(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseVar handles replacement variables (e.g. the 'var' in {{ var }}).
-func parseVar(ctx *lexparse.ParserContext[*tmplNode]) error {
-	switch token := ctx.Next(); token.Type {
+func parseVar(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case lexTypeIdentifier:
 		// Validate the variable name.
 		if !idenRegexp.MatchString(token.Value) {
@@ -268,7 +268,7 @@ func parseVar(ctx *lexparse.ParserContext[*tmplNode]) error {
 		}
 
 		// Add a variable node.
-		_ = ctx.Node(&tmplNode{
+		_ = cur.Node(&tmplNode{
 			typ:     nodeTypeVar,
 			varName: token.Value,
 		})
@@ -282,11 +282,11 @@ func parseVar(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseVarEnd handles var end (e.g. '}}').
-func parseVarEnd(ctx *lexparse.ParserContext[*tmplNode]) error {
-	switch token := ctx.Next(); token.Type {
+func parseVarEnd(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case lexTypeVarEnd:
 		// Go back to parsing template init state.
-		ctx.PushState(lexparse.ParseStateFn(parseSeq))
+		cur.PushState(lexparse.ParseStateFn(parseSeq))
 		return nil
 	case lexparse.TokenTypeEOF:
 		return fmt.Errorf("%w: unclosed variable, expected %q", io.ErrUnexpectedEOF, tokenVarEnd)
@@ -296,19 +296,19 @@ func parseVarEnd(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseBranch handles the start if conditional block.
-func parseBranch(ctx *lexparse.ParserContext[*tmplNode]) error {
-	switch token := ctx.Next(); token.Type {
+func parseBranch(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case lexTypeIdentifier:
 		if token.Value != tokenIf {
 			return fmt.Errorf("%w: expected %q", errIdentifier, tokenIf)
 		}
 
 		// Add a branch node.
-		_ = ctx.Push(&tmplNode{
+		_ = cur.Push(&tmplNode{
 			typ: nodeTypeBranch,
 		})
 
-		ctx.PushState(
+		cur.PushState(
 			// Parse the conditional expression.  Currently only a simple
 			// variable is supported.
 			lexparse.ParseStateFn(parseVar),
@@ -332,25 +332,25 @@ func parseBranch(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseIf handles the if body.
-func parseIf(ctx *lexparse.ParserContext[*tmplNode]) error {
+func parseIf(_ context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
 	// Add an if body sequence node.
-	_ = ctx.Push(&tmplNode{
+	_ = cur.Push(&tmplNode{
 		typ: nodeTypeSeq,
 	})
 
-	ctx.PushState(lexparse.ParseStateFn(parseSeq))
+	cur.PushState(lexparse.ParseStateFn(parseSeq))
 
 	return nil
 }
 
 // parseElse handles an else (or endif) block.
-func parseElse(ctx *lexparse.ParserContext[*tmplNode]) error {
-	token := ctx.Peek()
+func parseElse(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	token := cur.Peek(ctx)
 
 	switch token.Type {
 	case lexTypeIdentifier:
 		// Validate we are at a sequence node.
-		if cur := ctx.Pos(); cur.Value.typ != nodeTypeSeq {
+		if cur := cur.Pos(); cur.Value.typ != nodeTypeSeq {
 			return lexTokenErr(errIdentifier, token)
 		}
 	case lexparse.TokenTypeEOF:
@@ -362,22 +362,22 @@ func parseElse(ctx *lexparse.ParserContext[*tmplNode]) error {
 	switch token.Value {
 	case tokenElse:
 		// Consume the token.
-		_ = ctx.Next()
+		_ = cur.Next(ctx)
 
 		// Climb the tree back to the conditional.
-		ctx.Climb()
+		cur.Climb()
 
 		// Validate that we are in a conditional and there isn't already an else branch.
-		if cur := ctx.Pos(); cur.Value.typ != nodeTypeBranch || len(cur.Children) != 2 {
+		if cur := cur.Pos(); cur.Value.typ != nodeTypeBranch || len(cur.Children) != 2 {
 			return lexTokenErr(errIdentifier, token)
 		}
 
 		// Add an else sequence node to the conditional.
-		_ = ctx.Push(&tmplNode{
+		_ = cur.Push(&tmplNode{
 			typ: nodeTypeSeq,
 		})
 
-		ctx.PushState(
+		cur.PushState(
 			// Parse the '%}'
 			lexparse.ParseStateFn(parseBlockEnd),
 
@@ -388,7 +388,7 @@ func parseElse(ctx *lexparse.ParserContext[*tmplNode]) error {
 			lexparse.ParseStateFn(parseEndif),
 		)
 	case tokenEndif:
-		ctx.PushState(lexparse.ParseStateFn(parseEndif))
+		cur.PushState(lexparse.ParseStateFn(parseEndif))
 	default:
 		return lexTokenErr(fmt.Errorf("%w: looking for %q or %q", errIdentifier, tokenElse, tokenEndif), token)
 	}
@@ -397,20 +397,20 @@ func parseElse(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseEndif handles either an endif block.
-func parseEndif(ctx *lexparse.ParserContext[*tmplNode]) error {
-	switch token := ctx.Next(); token.Type {
+func parseEndif(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case lexTypeIdentifier:
 		if token.Value != tokenEndif {
 			return lexTokenErr(fmt.Errorf("%w: looking for %q", errIdentifier, tokenEndif), token)
 		}
 
 		// Climb out of the sequence node.
-		ctx.Climb()
+		cur.Climb()
 
 		// Climb out of the branch node.
-		ctx.Climb()
+		cur.Climb()
 
-		ctx.PushState(
+		cur.PushState(
 			// parse the '%}'
 			lexparse.ParseStateFn(parseBlockEnd),
 
@@ -427,9 +427,9 @@ func parseEndif(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseBlockStart handles the start of a template block '{%'.
-func parseBlockStart(ctx *lexparse.ParserContext[*tmplNode]) error {
+func parseBlockStart(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
 	// Validate the block start token.
-	switch token := ctx.Next(); token.Type {
+	switch token := cur.Next(ctx); token.Type {
 	case lexTypeBlockStart:
 		// OK
 	case lexparse.TokenTypeEOF:
@@ -439,7 +439,7 @@ func parseBlockStart(ctx *lexparse.ParserContext[*tmplNode]) error {
 	}
 
 	// Validate the command token.
-	token := ctx.Peek()
+	token := cur.Peek(ctx)
 	switch token.Type {
 	case lexTypeIdentifier:
 		// OK
@@ -453,7 +453,7 @@ func parseBlockStart(ctx *lexparse.ParserContext[*tmplNode]) error {
 	// Handle the block command.
 	switch token.Value {
 	case tokenIf:
-		ctx.PushState(lexparse.ParseStateFn(parseBranch))
+		cur.PushState(lexparse.ParseStateFn(parseBranch))
 	case tokenElse, tokenEndif:
 		// NOTE: parseElse, parseEndif should already be on the stack.
 	default:
@@ -465,8 +465,8 @@ func parseBlockStart(ctx *lexparse.ParserContext[*tmplNode]) error {
 }
 
 // parseBlockEnd handles the end of a template block '%}'.
-func parseBlockEnd(ctx *lexparse.ParserContext[*tmplNode]) error {
-	switch token := ctx.Next(); token.Type {
+func parseBlockEnd(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error {
+	switch token := cur.Next(ctx); token.Type {
 	case lexTypeBlockEnd:
 		return nil
 	case lexparse.TokenTypeEOF:

--- a/template_example_test.go
+++ b/template_example_test.go
@@ -350,7 +350,7 @@ func parseElse(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error 
 	switch token.Type {
 	case lexTypeIdentifier:
 		// Validate we are at a sequence node.
-		if cur := cur.Pos(); cur.Value.typ != nodeTypeSeq {
+		if curPos := cur.Pos(); curPos.Value.typ != nodeTypeSeq {
 			return lexTokenErr(errIdentifier, token)
 		}
 	case lexparse.TokenTypeEOF:
@@ -368,7 +368,7 @@ func parseElse(ctx context.Context, cur *lexparse.ParseCursor[*tmplNode]) error 
 		cur.Climb()
 
 		// Validate that we are in a conditional and there isn't already an else branch.
-		if cur := cur.Pos(); cur.Value.typ != nodeTypeBranch || len(cur.Children) != 2 {
+		if curNode := cur.Pos(); curNode.Value.typ != nodeTypeBranch || len(curNode.Children) != 2 {
 			return lexTokenErr(errIdentifier, token)
 		}
 


### PR DESCRIPTION
**Description:**

- Rename `ParserContext` to `ParseCursor` and separate it from the `context.Context`.
- Add a `NewParseCursor` to allow creating a `ParseCursor`. This should be useful for testing parse functions individually.
- Rename `CustomLexerCursor` to `LexCursor` to make it a little less long-winded. Also rename `NewCustomLexerCursor` to `NewLexCursor`.

**Related Issues:**

- #188 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
